### PR TITLE
Add core unit tests and stabilize isolation query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,223 @@ kodiak/
 .idea
 .vscode
 results.xml
-venv
+.venv/
+venv/
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `duckdb_sqlalchemy/` contains the dialect implementation and helpers (for example `datatypes.py`, `url.py`, `olap.py`, `config.py`).
+- `duckdb_sqlalchemy/tests/` holds pytest suites; snapshot fixtures live in `duckdb_sqlalchemy/tests/snapshots/`.
+- `examples/` provides runnable examples such as `examples/sqlalchemy_example.py`.
+- Tooling and metadata are in `pyproject.toml`, `noxfile.py`, and `.pre-commit-config.yaml`.
+
+## Build, Test, and Development Commands
+- `pip install -e ".[dev]"` installs dev dependencies for local runs.
+- `pip install -e ".[dev,devtools]"` also installs `pre-commit`.
+- `nox -s tests` runs the full test matrix (multiple Python, DuckDB, and SQLAlchemy versions); expect this to be slow.
+- `pytest` runs tests in the current environment (useful for quick checks).
+- `nox -s ty` runs type checking with `ty`.
+- `pre-commit run --all-files` applies formatting/lint checks via the configured hooks.
+
+## Coding Style & Naming Conventions
+- Python code uses 4-space indentation and standard naming: `snake_case` for functions/variables and `CamelCase` for classes.
+- Linting and formatting are enforced with Ruff (`ruff` + `ruff-format`) via pre-commit.
+- Type hints are expected in new code; `ty` is the canonical checker.
+
+## Testing Guidelines
+- Tests use `pytest` with plugins including `pytest-cov`, `pytest-remotedata`, and `pytest-snapshot`.
+- Name tests `test_*.py` and keep them under `duckdb_sqlalchemy/tests/`.
+- Snapshot assertions are stored under `duckdb_sqlalchemy/tests/snapshots/` and should be updated intentionally.
+
+## Commit & Pull Request Guidelines
+- Recent history favors short, imperative subjects and occasionally uses Conventional Commit prefixes (for example `chore:`, `build:`).
+- PRs should include a clear summary, test results, and linked issues when applicable.
+- For user-facing changes, consider updating `CHANGELOG.md`.
+
+## Security & Configuration Tips
+- Never commit secrets. Use environment variables for MotherDuck tokens (`MOTHERDUCK_TOKEN` or `motherduck_token`).
+
+# Personal guidelines
+
+- Use `pre-commit` to run checks before committing.
+- Always create a new branch for each feature or bug fix. After you completed the work, create a pull request with a concise title and description of the changes. Then wait for tests to pass and finally merge the changes into the main branch.

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -149,6 +149,8 @@ class CursorWrapper:
                 assert parameters and len(parameters) == 2, parameters
                 view_name, df = parameters
                 self.__c.register(view_name, df)
+            elif statement.lower() == "show transaction isolation level":
+                self.__c.execute("select 'read committed' as transaction_isolation")
             elif parameters is None:
                 self.__c.execute(statement)
             else:

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -1,0 +1,370 @@
+from typing import cast
+
+import duckdb
+import pytest
+from sqlalchemy import Integer, String
+from sqlalchemy import exc as sa_exc
+
+from duckdb_sqlalchemy import (
+    URL,
+    ConnectionWrapper,
+    CursorWrapper,
+    Dialect,
+    _apply_motherduck_defaults,
+    _looks_like_motherduck,
+    _normalize_motherduck_config,
+    _supports,
+    olap,
+)
+from duckdb_sqlalchemy import datatypes as dt
+from duckdb_sqlalchemy.config import TYPES, apply_config, get_core_config
+
+
+def _cursor(conn: object) -> CursorWrapper:
+    wrapper = ConnectionWrapper(cast(duckdb.DuckDBPyConnection, conn))
+    return CursorWrapper(cast(duckdb.DuckDBPyConnection, conn), wrapper)
+
+
+def test_url_coerces_types_and_overrides() -> None:
+    url = URL(
+        database=":memory:",
+        query={"access_mode": "read_only", "flag": True, "drop": None},
+        access_mode="read_write",
+        enabled=False,
+        list_val=[1, "two"],
+        tuple_val=("a", 2),
+        empty=None,
+    )
+
+    assert url.query["access_mode"] == "read_write"
+    assert url.query["flag"] == "true"
+    assert url.query["enabled"] == "false"
+    assert url.query["list_val"] == ("1", "two")
+    assert url.query["tuple_val"] == ("a", "2")
+    assert "drop" not in url.query
+    assert "empty" not in url.query
+
+
+def test_create_connect_args_moves_user_query_param() -> None:
+    dialect = Dialect()
+    url = URL(database=":memory:", query={"user": "alice", "memory_limit": "1GB"})
+
+    args, kwargs = dialect.create_connect_args(url)
+
+    assert args == ()
+    assert kwargs["database"] == ":memory:?user=alice"
+    assert kwargs["url_config"] == {"memory_limit": "1GB"}
+
+
+def test_apply_config_uses_literal_processors() -> None:
+    dialect = Dialect()
+
+    class DummyConn:
+        def __init__(self) -> None:
+            self.executed = []
+
+        def execute(self, statement: str) -> None:
+            self.executed.append(statement)
+
+    conn = DummyConn()
+    ext = {"memory_limit": "1GB", "threads": 4, "enable_profiling": True}
+
+    apply_config(dialect, conn, ext)
+
+    processors = {k: v.literal_processor(dialect=dialect) for k, v in TYPES.items()}
+    expected = [
+        f"SET {key} = {processors[type(value)](value)}" for key, value in ext.items()
+    ]
+
+    assert conn.executed == expected
+
+
+def test_get_core_config_includes_motherduck_keys() -> None:
+    core = get_core_config()
+
+    expected = {
+        "motherduck_token",
+        "attach_mode",
+        "saas_mode",
+        "session_hint",
+        "access_mode",
+        "dbinstance_inactivity_ttl",
+        "motherduck_dbinstance_inactivity_ttl",
+    }
+    assert expected.issubset(core)
+
+
+def test_looks_like_motherduck_detection() -> None:
+    assert _looks_like_motherduck("md:db", {}) is True
+    assert _looks_like_motherduck("motherduck:db", {}) is True
+    assert _looks_like_motherduck("local.db", {"motherduck_token": "x"}) is True
+    assert _looks_like_motherduck("local.db", {}) is False
+
+
+def test_apply_motherduck_defaults_env_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = {}
+    monkeypatch.setenv("MOTHERDUCK_TOKEN", "token123")
+    monkeypatch.delenv("motherduck_token", raising=False)
+
+    _apply_motherduck_defaults(config, "md:my_db")
+
+    assert config["motherduck_token"] == "token123"
+
+
+def test_apply_motherduck_defaults_skips_non_md(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = {}
+    monkeypatch.setenv("MOTHERDUCK_TOKEN", "token123")
+    monkeypatch.delenv("motherduck_token", raising=False)
+
+    _apply_motherduck_defaults(config, "local.db")
+
+    assert "motherduck_token" not in config
+
+
+def test_apply_motherduck_defaults_requires_string() -> None:
+    with pytest.raises(TypeError):
+        _apply_motherduck_defaults({"motherduck_token": 123}, "md:db")
+
+
+def test_normalize_motherduck_config_alias() -> None:
+    config = {"dbinstance_inactivity_ttl": "1h"}
+    _normalize_motherduck_config(config)
+    assert config["motherduck_dbinstance_inactivity_ttl"] == "1h"
+
+    config = {
+        "dbinstance_inactivity_ttl": "1h",
+        "motherduck_dbinstance_inactivity_ttl": "2h",
+    }
+    _normalize_motherduck_config(config)
+    assert config["motherduck_dbinstance_inactivity_ttl"] == "2h"
+
+
+def test_has_comment_support_false_on_parser_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, *args, **kwargs):
+            raise _supports.duckdb.ParserException("nope")
+
+    monkeypatch.setattr(_supports.duckdb, "connect", lambda *_: DummyConn())
+
+    assert _supports.has_comment_support() is False
+
+
+def test_has_comment_support_true_when_no_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(_supports.duckdb, "connect", lambda *_: DummyConn())
+
+    assert _supports.has_comment_support() is True
+
+
+def test_identifier_preparer_separate_and_format_schema() -> None:
+    preparer = Dialect().identifier_preparer
+
+    assert preparer._separate("db.schema") == ("db", "schema")
+    assert preparer._separate('"my db"."my schema"') == ("my db", "my schema")
+    assert preparer._separate("schema") == (None, "schema")
+
+    formatted = preparer.format_schema('"my db".main')
+    assert formatted == '"my db".main'
+
+
+def test_table_function_error_without_table_valued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyFunc:
+        def __getattr__(self, name):
+            def _fn(*args, **kwargs):
+                return object()
+
+            return _fn
+
+    monkeypatch.setattr(olap, "func", DummyFunc())
+
+    with pytest.raises(NotImplementedError):
+        olap.table_function("read_parquet", "path", columns=["col"])
+
+
+def test_table_function_returns_function_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {}
+
+    class DummyFunc:
+        def __getattr__(self, name):
+            def _fn(*args, **kwargs):
+                called["name"] = name
+                called["args"] = args
+                called["kwargs"] = kwargs
+                return "ok"
+
+            return _fn
+
+    monkeypatch.setattr(olap, "func", DummyFunc())
+
+    result = olap.table_function("read_csv", "file.csv", header=True)
+
+    assert result == "ok"
+    assert called["name"] == "read_csv"
+    assert called["args"] == ("file.csv",)
+    assert called["kwargs"] == {"header": True}
+
+
+def test_cursorwrapper_execute_basic_paths() -> None:
+    class DummyConn:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def commit(self) -> None:
+            self.calls.append(("commit",))
+
+        def register(self, name, df) -> None:
+            self.calls.append(("register", name, df))
+
+        def execute(self, *args):
+            self.calls.append(("execute", args))
+
+    conn = DummyConn()
+    cursor = _cursor(conn)
+    df = object()
+
+    cursor.execute("COMMIT")
+    cursor.execute("register", ("view", df))
+    cursor.execute("select 1")
+    cursor.execute("select ?", (1,))
+
+    assert ("commit",) in conn.calls
+    assert ("register", "view", df) in conn.calls
+    assert ("execute", ("select 1",)) in conn.calls
+    assert ("execute", ("select ?", (1,))) in conn.calls
+
+
+def test_cursorwrapper_execute_show_isolation_level() -> None:
+    class DummyConn:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def execute(self, statement: str) -> None:
+            self.calls.append(statement)
+
+    conn = DummyConn()
+    cursor = _cursor(conn)
+
+    cursor.execute("show transaction isolation level")
+
+    assert conn.calls == ["select 'read committed' as transaction_isolation"]
+
+
+def test_cursorwrapper_executemany_coerces_to_list() -> None:
+    class DummyConn:
+        def __init__(self) -> None:
+            self.calls = []
+
+        def executemany(self, *args):
+            self.calls.append(args)
+
+    conn = DummyConn()
+    cursor = _cursor(conn)
+    params = ({"a": 1}, {"a": 2})
+
+    cursor.executemany("insert", params)  # type: ignore[arg-type]
+
+    assert conn.calls[0][0] == "insert"
+    assert conn.calls[0][1] == list(params)
+
+
+def test_cursorwrapper_execute_handles_specific_runtime_errors() -> None:
+    class CommitConn:
+        def commit(self) -> None:
+            raise RuntimeError(
+                "TransactionContext Error: cannot commit - no transaction is active"
+            )
+
+    cursor = _cursor(CommitConn())
+    cursor.execute("commit")
+
+    class NotImplementedConn:
+        def execute(self, *args, **kwargs):
+            raise RuntimeError("Not implemented Error: nope")
+
+    cursor = _cursor(NotImplementedConn())
+    with pytest.raises(NotImplementedError):
+        cursor.execute("select 1")
+
+
+def test_cursorwrapper_description_handles_unhashable_type_code() -> None:
+    class DummyConn:
+        description = [("col", ["complex"])]
+
+    cursor = _cursor(DummyConn())
+
+    assert cursor.description == [("col", "['complex']")]
+
+
+def test_connectionwrapper_close_marks_closed() -> None:
+    class DummyConn:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = DummyConn()
+    wrapper = ConnectionWrapper(cast(duckdb.DuckDBPyConnection, conn))
+    assert wrapper.closed is False
+
+    wrapper.close()
+
+    assert wrapper.closed is True
+    assert conn.closed is True
+
+
+def test_map_processors(monkeypatch: pytest.MonkeyPatch) -> None:
+    map_type = dt.Map(String, Integer)
+    bind = map_type.bind_processor(Dialect())
+
+    assert bind({"a": 1, "b": 2}) == {"key": ["a", "b"], "value": [1, 2]}
+    assert bind(None) is None
+
+    result = map_type.result_processor(Dialect(), None)({"key": ["a"], "value": [1]})
+    if dt.IS_GT_1:
+        assert result == {"key": ["a"], "value": [1]}
+    else:
+        assert result == {"a": 1}
+
+    monkeypatch.setattr(dt, "IS_GT_1", False)
+    legacy = dt.Map(String, Integer).result_processor(Dialect(), None)
+    assert legacy({"key": ["a"], "value": [1]}) == {"a": 1}
+    assert legacy(None) == {}
+
+
+def test_struct_or_union_requires_fields() -> None:
+    dialect = Dialect()
+    compiler = dialect.type_compiler
+    preparer = dialect.identifier_preparer
+
+    with pytest.raises(sa_exc.CompileError):
+        dt.struct_or_union(dt.Struct(), compiler, preparer)
+
+    struct = dt.Struct({"first name": String, "age": Integer})
+    rendered = dt.struct_or_union(struct, compiler, preparer)
+    assert rendered.startswith("(")
+    assert rendered.endswith(")")
+    assert '"first name"' in rendered

--- a/duckdb_sqlalchemy/tests/test_datatypes.py
+++ b/duckdb_sqlalchemy/tests/test_datatypes.py
@@ -237,7 +237,7 @@ def test_double_nested_types(engine: Engine, session: Session) -> None:
 
 def test_interval(engine: Engine, snapshot: Snapshot) -> None:
     test_table = Table("test_table", MetaData(), Column("duration", Interval))
-    create_sql = str(schema.CreateTable(test_table).compile(engine)).strip()
+    create_sql = f"{str(schema.CreateTable(test_table).compile(engine)).strip()}\n"
     snapshot.assert_match(create_sql, "schema.sql")
 
 


### PR DESCRIPTION
## Summary
- add AGENTS.md contributor guide
- add core unit tests for core utilities and wrappers
- handle "show transaction isolation level" in CursorWrapper
- align interval snapshot formatting

## Testing
- .venv/bin/python -m pytest -q