### PR TITLE
Simplify README and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,346 +1,59 @@
 # duckdb-sqlalchemy
 
-[![Supported Python Versions](https://img.shields.io/pypi/pyversions/duckdb-sqlalchemy)](https://pypi.org/project/duckdb-sqlalchemy/) [![PyPI version](https://badge.fury.io/py/duckdb-sqlalchemy.svg)](https://badge.fury.io/py/duckdb-sqlalchemy) [![PyPI Downloads](https://img.shields.io/pypi/dm/duckdb-sqlalchemy.svg)](https://pypi.org/project/duckdb-sqlalchemy/) [![codecov](https://codecov.io/gh/leonardovida/duckdb-sqlalchemy/graph/badge.svg)](https://codecov.io/gh/leonardovida/duckdb-sqlalchemy)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/duckdb-sqlalchemy)](https://pypi.org/project/duckdb-sqlalchemy/) [![PyPI version](https://badge.fury.io/py/duckdb-sqlalchemy.svg)](https://pypi.org/project/duckdb-sqlalchemy) [![PyPI Downloads](https://img.shields.io/pypi/dm/duckdb-sqlalchemy.svg)](https://pypi.org/project/duckdb-sqlalchemy/) [![codecov](https://codecov.io/gh/leonardovida/duckdb-sqlalchemy/graph/badge.svg)](https://codecov.io/gh/leonardovida/duckdb-sqlalchemy)
 
-SQLAlchemy driver for [DuckDB](https://duckdb.org/) and [MotherDuck](https://motherduck.com/).
+SQLAlchemy dialect for DuckDB and MotherDuck. Use it to run DuckDB locally or connect to MotherDuck with the standard SQLAlchemy APIs.
 
-<!--ts-->
-- [duckdb-sqlalchemy](#duckdb-sqlalchemy)
-  - [Installation](#installation)
-  - [Quickstart](#quickstart)
-  - [Connection URLs](#connection-urls)
-    - [URL helper](#url-helper)
-    - [MotherDuck](#motherduck)
-  - [OLAP workflows](#olap-workflows)
-    - [Parquet and CSV scans](#parquet-and-csv-scans)
-    - [Multi-database analytics with ATTACH](#multi-database-analytics-with-attach)
-  - [Usage in IPython/Jupyter](#usage-in-ipythonjupyter)
-  - [Configuration](#configuration)
-  - [How to register a pandas DataFrame](#how-to-register-a-pandas-dataframe)
-  - [Type support](#type-support)
-  - [Parameter binding](#parameter-binding)
-  - [Things to keep in mind](#things-to-keep-in-mind)
-    - [Auto-incrementing ID columns](#auto-incrementing-id-columns)
-    - [Pandas `read_sql()` chunksize](#pandas-read_sql-chunksize)
-    - [Unsigned integer support](#unsigned-integer-support)
-  - [Alembic Integration](#alembic-integration)
-  - [Preloading extensions (experimental)](#preloading-extensions-experimental)
-  - [Registering Filesystems](#registering-filesystems)
-  - [The name](#the-name)
-  - [Fork](#fork)
+## Install
 
-<!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: me, at: Wed 20 Sep 2023 12:44:27 AWST -->
-
-<!--te-->
-
-## Installation
 ```sh
-$ pip install duckdb-sqlalchemy
+pip install duckdb-sqlalchemy
 ```
 
-DuckDB SQLAlchemy also has a conda feedstock available, the instructions for the use of which are available in it's [repository](https://github.com/conda-forge/duckdb-sqlalchemy-feedstock).
+Conda packages are available via the conda-forge feedstock: https://github.com/conda-forge/duckdb-sqlalchemy-feedstock.
 
-## Quickstart
+## Quick start
 
 ```python
-from sqlalchemy import Column, Integer, Sequence, String, create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm.session import Session
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, Session
 
 Base = declarative_base()
 
 
-class FakeModel(Base):  # type: ignore
-    __tablename__ = "fake"
+class User(Base):
+    __tablename__ = "users"
 
-    id = Column(Integer, Sequence("fakemodel_id_sequence"), primary_key=True)
+    id = Column(Integer, primary_key=True)
     name = Column(String)
 
 
-eng = create_engine("duckdb:///:memory:")
-Base.metadata.create_all(eng)
-session = Session(bind=eng)
+engine = create_engine("duckdb:///:memory:")
+Base.metadata.create_all(engine)
 
-session.add(FakeModel(name="Frank"))
-session.commit()
-
-frank = session.query(FakeModel).one()
-
-assert frank.name == "Frank"
+with Session(engine) as session:
+    session.add(User(name="Ada"))
+    session.commit()
+    assert session.query(User).one().name == "Ada"
 ```
 
-See `examples/sqlalchemy_example.py` for a longer end-to-end example.
+## Documentation
 
-## Connection URLs
+Start here for focused, task-based docs:
 
-DuckDB URLs follow the standard SQLAlchemy format:
+- `docs/README.md` - Docs index
+- `docs/connection-urls.md` - URL formats and helpers
+- `docs/motherduck.md` - MotherDuck setup and options
+- `docs/configuration.md` - Connection configuration, extensions, filesystems
+- `docs/olap.md` - Parquet/CSV scans and ATTACH workflows
+- `docs/pandas-jupyter.md` - DataFrame registration and notebook usage
+- `docs/types-and-caveats.md` - Type support and known caveats
+- `docs/alembic.md` - Alembic integration
 
-```
-duckdb:///<database>?<config>
-```
+## Examples
 
-Examples:
+- `examples/sqlalchemy_example.py` - end-to-end example
 
-```
-duckdb:///:memory:
-duckdb:///analytics.db
-```
+## Contributing
 
-### URL helper
-
-For programmatic construction (and automatic escaping), use the helper:
-
-```python
-import os
-from sqlalchemy import create_engine
-from duckdb_sqlalchemy import URL
-
-url = URL(
-    database=":memory:",
-    memory_limit="1GB",
-)
-engine = create_engine(url)
-
-md_url = URL(
-    database="md:my_db",
-    motherduck_token=os.environ["MOTHERDUCK_TOKEN"],
-)
-md_engine = create_engine(md_url)
-```
-
-If you build URLs manually and your token contains special characters, escape it:
-
-```python
-from urllib.parse import quote_plus
-
-escaped = quote_plus(os.environ["MOTHERDUCK_TOKEN"])
-engine = create_engine(f"duckdb:///md:my_db?motherduck_token={escaped}")
-```
-
-### MotherDuck
-
-MotherDuck connections use the `md:` database prefix and support connection-time
-configuration options like:
-
-- `motherduck_token` (can also be provided via `motherduck_token` or `MOTHERDUCK_TOKEN` env vars)
-- `attach_mode` (`workspace` or `single`)
-- `saas_mode` (`true`/`false`)
-- `session_hint` (for read-scaling session affinity)
-- `access_mode` (`read_only` for read scaling tokens)
-- `dbinstance_inactivity_ttl` (alias for `motherduck_dbinstance_inactivity_ttl`)
-
-If `motherduck_token` (lowercase) or `MOTHERDUCK_TOKEN` is set in the environment,
-it will be used automatically when you connect to `md:` databases.
-
-```
-duckdb:///md:
-duckdb:///md:my_db?attach_mode=single
-duckdb:///md:my_db?session_hint=user123&access_mode=read_only
-duckdb:///md:my_db?dbinstance_inactivity_ttl=1h
-```
-
-## OLAP workflows
-
-### Parquet and CSV scans
-
-DuckDB exposes analytics-friendly table functions like `read_parquet` and
-`read_csv_auto`. The `duckdb_sqlalchemy.olap` helpers make these easy to use with
-SQLAlchemy:
-
-```python
-from sqlalchemy import select
-from duckdb_sqlalchemy import read_parquet, read_csv_auto
-
-parquet = read_parquet("data/events.parquet", columns=["event_id", "ts"])
-stmt = select(parquet.c.event_id, parquet.c.ts)
-
-csv = read_csv_auto("data/events.csv", columns=["event_id", "ts"])
-stmt = select(csv.c.event_id, csv.c.ts)
-```
-
-### Multi-database analytics with ATTACH
-
-DuckDB can query across multiple databases in a single session:
-
-```python
-from sqlalchemy import text
-
-conn = create_engine("duckdb:///local.duckdb").connect()
-conn.execute(text("ATTACH 'analytics.duckdb' AS analytics"))
-conn.execute(text("SELECT * FROM analytics.events LIMIT 10"))
-```
-
-## Usage in IPython/Jupyter
-
-With IPython-SQL and DuckDB SQLAlchemy you can query DuckDB natively in your notebook! Check out [DuckDB's documentation](https://duckdb.org/docs/guides/python/jupyter) or
-Alex Monahan's great demo of this on [his blog](https://alex-monahan.github.io/2021/08/22/Python_and_SQL_Better_Together.html#an-example-workflow-with-duckdb).
-
-## Configuration
-
-You can configure DuckDB by passing `connect_args` to the create_engine function:
-
-```python
-create_engine(
-    "duckdb:///:memory:",
-    connect_args={
-        "read_only": False,
-        "config": {
-            "memory_limit": "500mb",
-        },
-    },
-)
-```
-
-The supported configuration parameters are listed in the [DuckDB docs](https://duckdb.org/docs/sql/configuration).
-
-## How to register a pandas DataFrame
-
-```python
-conn = create_engine("duckdb:///:memory:").connect()
-
-# with SQLAlchemy 1.3
-conn.execute("register", ("dataframe_name", pd.DataFrame(...)))
-
-# with SQLAlchemy 1.4+
-conn.execute(text("register(:name, :df)"), {"name": "test_df", "df": df})
-
-conn.execute("select * from dataframe_name")
-```
-
-## Type support
-
-Most SQLAlchemy core types map directly to DuckDB. DuckDB-specific helpers are
-available in `duckdb_sqlalchemy.datatypes`:
-
-| Type | DuckDB name | Notes |
-| --- | --- | --- |
-| `UInt8`, `UInt16`, `UInt32`, `UInt64`, `UTinyInteger`, `USmallInteger`, `UInteger`, `UBigInteger` | UTINYINT, USMALLINT, UINTEGER, UBIGINT | Unsigned integers |
-| `TinyInteger` | TINYINT | Signed 1-byte integer |
-| `HugeInteger`, `UHugeInteger`, `VarInt` | HUGEINT, UHUGEINT, VARINT | 128-bit and variable-length integers (VarInt requires DuckDB >= 1.0) |
-| `Struct` | STRUCT | Nested fields via dict of SQLAlchemy types |
-| `Map` | MAP | Key/value mapping |
-| `Union` | UNION | Union types via dict of SQLAlchemy types |
-
-## Parameter binding
-
-SQLAlchemy parameter styles are handled by the dialect. Use named parameters in
-SQLAlchemy expressions and let the engine handle the database-specific format:
-
-```python
-from sqlalchemy import text
-
-stmt = text("SELECT * FROM events WHERE event_id = :event_id")
-conn.execute(stmt, {"event_id": 123})
-```
-
-For SQLAlchemy 2.x, parameters compile to `$1`, `$2`, ...; SQLAlchemy 1.x uses
-`?` placeholders.
-
-## Things to keep in mind
-Duckdb's SQL parser is based on the PostgreSQL parser, but not all features in PostgreSQL are supported in duckdb. Because the `duckdb_sqlalchemy` dialect is derived from the `postgresql` dialect, `SQLAlchemy` may try to use PostgreSQL-only features. Below are some caveats to look out for.
-
-### Auto-incrementing ID columns
-When defining an Integer column as a primary key, `SQLAlchemy` uses the `SERIAL` datatype for PostgreSQL. Duckdb does not yet support this datatype because it's a non-standard PostgreSQL legacy type, so a workaround is to use the `SQLAlchemy.Sequence()` object to auto-increment the key. For more information on sequences, you can find the [`SQLAlchemy Sequence` documentation here](https://docs.sqlalchemy.org/en/14/core/defaults.html#associating-a-sequence-as-the-server-side-default).
-
-The following example demonstrates how to create an auto-incrementing ID column for a simple table:
-
-```python
->>> import sqlalchemy
->>> engine = sqlalchemy.create_engine("duckdb:////path/to/duck.db")
->>> metadata = sqlalchemy.MetaData(engine)
->>> user_id_seq = sqlalchemy.Sequence("user_id_seq")
->>> users_table = sqlalchemy.Table(
-...     "users",
-...     metadata,
-...     sqlalchemy.Column(
-...         "id",
-...         sqlalchemy.Integer,
-...         user_id_seq,
-...         server_default=user_id_seq.next_value(),
-...         primary_key=True,
-...     ),
-... )
->>> metadata.create_all(bind=engine)
-```
-
-### Pandas `read_sql()` chunksize
-
-**NOTE**: this is no longer an issue in versions `>=0.5.0` of `duckdb`
-
-The `pandas.read_sql()` method can read tables from `duckdb_sqlalchemy` into DataFrames, but the `sqlalchemy.engine.result.ResultProxy` trips up when `fetchmany()` is called. Therefore, for now `chunksize=None` (default) is necessary when reading duckdb tables into DataFrames. For example:
-
-```python
->>> import pandas as pd
->>> import sqlalchemy
->>> engine = sqlalchemy.create_engine("duckdb:////path/to/duck.db")
->>> df = pd.read_sql("users", engine)                ### Works as expected
->>> df = pd.read_sql("users", engine, chunksize=25)  ### Throws an exception
-```
-
-### Unsigned integer support
-
-Unsigned integers are supported by DuckDB, and are available in [`duckdb_sqlalchemy.datatypes`](duckdb_sqlalchemy/datatypes.py).
-
-## Alembic Integration
-
-SQLAlchemy's companion library `alembic` can optionally be used to manage database migrations.
-
-This support can be enabling by adding an Alembic implementation class for the `duckdb` dialect.
-
-```python
-from alembic.ddl.impl import DefaultImpl
-
-class AlembicDuckDBImpl(DefaultImpl):
-    """Alembic implementation for DuckDB."""
-
-    __dialect__ = "duckdb"
-```
-
-After loading this class with your program, Alembic will no longer raise an error when generating or applying migrations.
-
-## Preloading extensions (experimental)
-
-> DuckDB 0.9.0+ includes builtin support for autoinstalling and autoloading of extensions, see [the extension documentation](http://duckdb.org/docs/archive/0.9.0/extensions/overview#autoloadable-extensions) for more information.
-
-Until the DuckDB python client allows you to natively preload extensions, I've added experimental support via a `connect_args` parameter
-
-```python
-from sqlalchemy import create_engine
-
-create_engine(
-    "duckdb:///:memory:",
-    connect_args={
-        "preload_extensions": ["https"],
-        "config": {
-            "s3_region": "ap-southeast-1",
-        },
-    },
-)
-```
-
-## Registering Filesystems
-
-> DuckDB allows registering filesystems from [fsspec](https://filesystem-spec.readthedocs.io/), see [documentation](https://duckdb.org/docs/guides/python/filesystems.html) for more information.
-
-Support is provided under `connect_args` parameter
-
-```python
-from sqlalchemy import create_engine
-from fsspec import filesystem
-
-create_engine(
-    "duckdb:///:memory:",
-    connect_args={
-        "register_filesystems": [filesystem("gcs")],
-    },
-)
-```
-
-## The name
-
-This project is published as `duckdb-sqlalchemy` (imported as `duckdb_sqlalchemy`) to match the repository and package name.
-
-## Fork
-
-This repository is a fork of the original DuckDB SQLAlchemy driver by Elliana May (https://github.com/Mause/duckdb_engine). We keep the fork history and attribution intact.
+See `AGENTS.md` for repo-specific workflow and PR expectations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Documentation
+
+This folder contains focused, task-oriented guides that keep the main README short. Start with the section closest to your workflow and follow the links as needed.
+
+## Guides
+
+- `connection-urls.md` - URL formats, helpers, and manual escaping
+- `motherduck.md` - Connection patterns and MotherDuck-specific options
+- `configuration.md` - `connect_args`, extension preloads, and filesystem registration
+- `olap.md` - Table functions (`read_parquet`, `read_csv_auto`) and ATTACH examples
+- `pandas-jupyter.md` - DataFrame registration and notebook usage
+- `types-and-caveats.md` - Supported types, parameter binding, and gotchas
+- `alembic.md` - Alembic integration notes
+
+## Examples
+
+The `examples/` directory contains runnable scripts. If you want a full end-to-end walkthrough, start with `examples/sqlalchemy_example.py`.

--- a/docs/alembic.md
+++ b/docs/alembic.md
@@ -1,0 +1,13 @@
+# Alembic integration
+
+SQLAlchemy's migration tool, Alembic, can be used with DuckDB by providing a dialect implementation class.
+
+```python
+from alembic.ddl.impl import DefaultImpl
+
+
+class AlembicDuckDBImpl(DefaultImpl):
+    __dialect__ = "duckdb"
+```
+
+Load this class in your Alembic environment to enable migration generation and application without dialect errors.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,52 @@
+# Configuration
+
+DuckDB configuration can be supplied via `connect_args` or URL query params.
+
+## `connect_args` basics
+
+```python
+from sqlalchemy import create_engine
+
+engine = create_engine(
+    "duckdb:///:memory:",
+    connect_args={
+        "read_only": False,
+        "config": {
+            "memory_limit": "500MB",
+            "threads": 4,
+        },
+    },
+)
+```
+
+The supported keys are DuckDB configuration settings. See the DuckDB docs for the authoritative list.
+
+## Preload extensions
+
+DuckDB can auto-install and auto-load extensions. You can preload extensions during connection:
+
+```python
+engine = create_engine(
+    "duckdb:///:memory:",
+    connect_args={
+        "preload_extensions": ["https"],
+        "config": {"s3_region": "ap-southeast-1"},
+    },
+)
+```
+
+## Register filesystems
+
+You can register filesystems via `fsspec`:
+
+```python
+from fsspec import filesystem
+from sqlalchemy import create_engine
+
+engine = create_engine(
+    "duckdb:///:memory:",
+    connect_args={
+        "register_filesystems": [filesystem("gcs")],
+    },
+)
+```

--- a/docs/connection-urls.md
+++ b/docs/connection-urls.md
@@ -1,0 +1,47 @@
+# Connection URLs
+
+DuckDB URLs follow the standard SQLAlchemy shape:
+
+```
+duckdb:///<database>?<config>
+```
+
+## Common examples
+
+```
+duckdb:///:memory:
+duckdb:///analytics.db
+```
+
+Use absolute paths when you need a specific location:
+
+```
+duckdb:////absolute/path/to/analytics.db
+```
+
+## URL helper
+
+Use the `URL` helper to build URLs safely (it handles booleans and sequences for you):
+
+```python
+from sqlalchemy import create_engine
+from duckdb_sqlalchemy import URL
+
+url = URL(database=":memory:", read_only=False, memory_limit="1GB")
+engine = create_engine(url)
+```
+
+## Manual escaping
+
+If you build URLs manually and your token contains special characters, escape it:
+
+```python
+import os
+from urllib.parse import quote_plus
+from sqlalchemy import create_engine
+
+escaped = quote_plus(os.environ["MOTHERDUCK_TOKEN"])
+engine = create_engine(f"duckdb:///md:my_db?motherduck_token={escaped}")
+```
+
+See `motherduck.md` for MotherDuck-specific examples and options.

--- a/docs/motherduck.md
+++ b/docs/motherduck.md
@@ -1,0 +1,42 @@
+# MotherDuck
+
+MotherDuck connections use the `md:` database prefix.
+
+```python
+from sqlalchemy import create_engine
+
+engine = create_engine("duckdb:///md:my_db")
+```
+
+## Tokens
+
+Set `MOTHERDUCK_TOKEN` (or `motherduck_token`) in the environment and it will be picked up automatically when you connect to `md:` databases.
+
+```bash
+export MOTHERDUCK_TOKEN="..."
+```
+
+You can also pass the token in the URL or via `connect_args`:
+
+```python
+engine = create_engine(
+    "duckdb:///md:my_db",
+    connect_args={"config": {"motherduck_token": "..."}},
+)
+```
+
+## Options
+
+Common connection options (all passed as URL query params or via `connect_args["config"]`):
+
+- `attach_mode`: `workspace` or `single`
+- `saas_mode`: `true` or `false`
+- `session_hint`: read-scaling session affinity
+- `access_mode`: `read_only` for read-scaling tokens
+- `dbinstance_inactivity_ttl`: alias for `motherduck_dbinstance_inactivity_ttl`
+
+Example:
+
+```
+duckdb:///md:my_db?attach_mode=single&access_mode=read_only
+```

--- a/docs/olap.md
+++ b/docs/olap.md
@@ -1,0 +1,30 @@
+# OLAP workflows
+
+DuckDB exposes analytics-friendly table functions like `read_parquet` and `read_csv_auto`. The helpers in `duckdb_sqlalchemy.olap` make these easy to use with SQLAlchemy.
+
+```python
+from sqlalchemy import select
+from duckdb_sqlalchemy import read_parquet, read_csv_auto
+
+parquet = read_parquet("data/events.parquet", columns=["event_id", "ts"])
+stmt = select(parquet.c.event_id, parquet.c.ts)
+
+csv = read_csv_auto("data/events.csv", columns=["event_id", "ts"])
+stmt = select(csv.c.event_id, csv.c.ts)
+```
+
+## ATTACH for multi-database analytics
+
+DuckDB can query across multiple databases in a single session:
+
+```python
+from sqlalchemy import create_engine, text
+
+conn = create_engine("duckdb:///local.duckdb").connect()
+conn.execute(text("ATTACH 'analytics.duckdb' AS analytics"))
+rows = conn.execute(text("SELECT * FROM analytics.events LIMIT 10")).fetchall()
+```
+
+## Notes
+
+- Column naming for table functions requires SQLAlchemy >= 1.4 (uses `table_valued`).

--- a/docs/pandas-jupyter.md
+++ b/docs/pandas-jupyter.md
@@ -1,0 +1,41 @@
+# Pandas and Jupyter
+
+## Register a DataFrame
+
+DuckDB can query a pandas DataFrame by registering it as a view.
+
+```python
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+engine = create_engine("duckdb:///:memory:")
+conn = engine.connect()
+
+df = pd.DataFrame({"id": [1, 2], "name": ["Ada", "Grace"]})
+
+# SQLAlchemy 1.3
+conn.execute("register", ("people", df))
+
+# SQLAlchemy 1.4+
+# conn.execute(text("register(:name, :df)"), {"name": "people", "df": df})
+
+rows = conn.execute(text("select * from people")).fetchall()
+```
+
+## read_sql / to_sql
+
+Pandas works with the SQLAlchemy engine:
+
+```python
+import pandas as pd
+from sqlalchemy import create_engine
+
+engine = create_engine("duckdb:///:memory:")
+
+pd.DataFrame({"a": [1, 2]}).to_sql("t", engine, index=False, if_exists="replace")
+result = pd.read_sql("select * from t", engine)
+```
+
+## Jupyter (IPython SQL)
+
+DuckDB works with `jupysql`/`ipython-sql`. Configure the SQLAlchemy engine and use the notebook extension to run SQL directly against DuckDB.


### PR DESCRIPTION
## Summary
- replace the long README with a simpler overview and doc links
- add focused guides under docs/ for URLs, MotherDuck, configuration, OLAP, pandas, types, and Alembic
- keep examples in examples/ and point to them from the README

## Testing
- not run (docs-only changes)