### PR TITLE
chore: release 0.19.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+SQLAlchemy dialect for DuckDB and MotherDuck. Provides first-class SQLAlchemy Core + ORM support with MotherDuck-specific helpers for connection URLs, pooling, and read scaling.
+
+## Build and Development Commands
+
+```bash
+# Install dev dependencies
+pip install -e ".[dev]"
+
+# Install with pre-commit support
+pip install -e ".[dev,devtools]"
+
+# Run tests in current environment (quick)
+pytest
+
+# Run single test
+pytest duckdb_sqlalchemy/tests/test_basic.py::test_name -v
+
+# Run full test matrix (slow - multiple Python/DuckDB/SQLAlchemy versions)
+nox -s tests
+
+# Type checking
+nox -s ty
+# or directly
+ty check duckdb_sqlalchemy/
+
+# Lint and format
+pre-commit run --all-files
+```
+
+## Architecture
+
+The dialect implementation lives in `duckdb_sqlalchemy/__init__.py` and extends PostgreSQL's dialect (`PGDialect_psycopg2`) since DuckDB's SQL is PostgreSQL-compatible. Key components:
+
+- **Dialect** (`__init__.py`): Main SQLAlchemy dialect class with connection handling, reflection, and DuckDB-specific execution context
+- **ConnectionWrapper/CursorWrapper**: DBAPI-compliant wrappers around `duckdb.DuckDBPyConnection` with special handling for `register`, `commit`, and transaction isolation queries
+- **url.py / motherduck.py**: URL builders (`URL`, `MotherDuckURL`) and helpers for connection string construction, token handling, and attach modes
+- **datatypes.py**: Type mappings from DuckDB types to SQLAlchemy types (ISCHEMA_NAMES)
+- **olap.py**: Table functions for `read_parquet`, `read_csv`, etc.
+- **config.py**: DuckDB configuration handling and extension loading
+- **bulk.py**: Bulk insert helpers (`copy_from_parquet`, `copy_from_csv`, `copy_from_rows`)
+
+## Key Implementation Details
+
+- The dialect uses `numeric_dollar` paramstyle for SQLAlchemy 2.x, `qmark` for 1.x
+- Pool defaults: `NullPool` for file/MotherDuck, `SingletonThreadPool` for `:memory:`
+- Bulk inserts over `duckdb_copy_threshold` (default 10k rows) use DataFrame/Arrow registration
+- MotherDuck tokens are read from `MOTHERDUCK_TOKEN` environment variable automatically
+
+## Testing
+
+Tests are in `duckdb_sqlalchemy/tests/`. The nox matrix tests across:
+- Python 3.10-3.13
+- SQLAlchemy 1.3, 1.4, 2.0.45
+- DuckDB 1.1.3 through 1.4.x
+
+Snapshot fixtures are in `duckdb_sqlalchemy/tests/snapshots/`.
+
+## Code Style
+
+- 4-space indentation, `snake_case` functions, `CamelCase` classes
+- Type hints expected in new code; `ty` is the type checker
+- Ruff handles linting and formatting

--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 # duckdb-sqlalchemy
 
 [![PyPI version](https://badge.fury.io/py/duckdb-sqlalchemy.svg)](https://pypi.org/project/duckdb-sqlalchemy)
-[![Supported Python Versions](https://img.shields.io/pypi/pyversions/duckdb-sqlalchemy)](https://pypi.org/project/duckdb-sqlalchemy/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/duckdb-sqlalchemy.svg)](https://pypi.org/project/duckdb-sqlalchemy/)
-[![CI](https://github.com/leonardovida/duckdb-sqlalchemy/actions/workflows/pythonapp.yaml/badge.svg)](https://github.com/leonardovida/duckdb-sqlalchemy/actions/workflows/pythonapp.yaml)
 [![codecov](https://codecov.io/gh/leonardovida/duckdb-sqlalchemy/graph/badge.svg)](https://codecov.io/gh/leonardovida/duckdb-sqlalchemy)
-[![License](https://img.shields.io/pypi/l/duckdb-sqlalchemy)](LICENSE.txt)
 
-SQLAlchemy dialect for DuckDB and MotherDuck. Run DuckDB locally or connect to MotherDuck with the standard SQLAlchemy APIs. This maintained fork tracks current DuckDB releases and includes MotherDuck-specific helpers and reliability improvements compared to legacy forks.
+The production-grade SQLAlchemy dialect for DuckDB and MotherDuck. Use the full SQLAlchemy Core and ORM APIs with DuckDB's analytical engine, locally or in the cloud via MotherDuck.
 
-## Highlights
+This dialect handles connection pooling, bulk inserts, type mappings, and cloud-specific configuration so you can focus on queries instead of driver quirks.
 
-- First-class SQLAlchemy dialect (Core + ORM) for DuckDB and MotherDuck.
-- Clean connection URL helpers for MotherDuck routing, attach modes, and read scaling.
-- Practical defaults for pooling, pre-ping, and long-lived app workloads.
-- Optional transient retry for idempotent reads.
-- Actively maintained with a long-term support mindset.
+## Why this dialect
+
+- **Full SQLAlchemy compatibility**: Core, ORM, Alembic migrations, and reflection work out of the box.
+- **MotherDuck support**: Automatic token handling, attach modes, session hints, and read scaling helpers.
+- **Production defaults**: Sensible pooling, transient retry for reads, and bulk insert optimization via Arrow/DataFrame registration.
+- **Actively maintained**: Tracks current DuckDB releases with long-term support commitment.
 
 ## Compatibility
 
@@ -23,15 +21,13 @@ SQLAlchemy dialect for DuckDB and MotherDuck. Run DuckDB locally or connect to M
 | --- | --- |
 | Python | 3.9+ |
 | SQLAlchemy | 1.3.22+ (2.x recommended) |
-| DuckDB | 0.5.0+ (latest recommended) |
+| DuckDB | 1.3.0+ (1.4.3 recommended) |
 
 ## Install
 
 ```sh
 pip install duckdb-sqlalchemy
 ```
-
-Conda packages are available via conda-forge: https://github.com/conda-forge/duckdb-sqlalchemy-feedstock.
 
 ## Quick start (DuckDB)
 

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -60,7 +60,7 @@ try:
 except ImportError:  # pragma: no cover - fallback for older SQLAlchemy
     PGExecutionContext = DefaultExecutionContext
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "0.19.0"
+version = "0.19.1"
 description = "SQLAlchemy driver for duckdb"
 authors = [
     {name = "Leonardo Vida", email = "leonardo@motherduck.com"},


### PR DESCRIPTION
## Summary

- Streamlined README with production-focused messaging
- Updated DuckDB compatibility requirement to 1.3.0+ (1.4.3 recommended)
- Cleaned up badges (kept PyPI version, downloads, codecov)
- Removed conda-forge reference
- Added CLAUDE.md for AI-assisted development

## Test plan

- [ ] CI passes
- [ ] README renders correctly on PyPI after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)