### PR TITLE
ci: drop testpypi publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,13 +1,5 @@
 name: Publish Python package
 on:
-  workflow_dispatch:
-    inputs:
-      target:
-        description: "Where to publish"
-        required: true
-        type: choice
-        options:
-          - testpypi
   release:
     types: [published]
 
@@ -58,28 +50,3 @@ jobs:
         path: dist/
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish-to-testpypi:
-    name: Publish to TestPyPI
-    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
-    needs: build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/duckdb-sqlalchemy
-
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary
- remove TestPyPI workflow dispatch and publish job

## Testing
- pre-commit (yaml)