### PR TITLE
chore: release 0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ preserved from the upstream project for historical context.
 
 ## Maintained in this fork
 
+## [0.19.3](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v0.19.2...v0.19.3) (2025-12-28)
+
+### Documentation
+
+* publish GitHub Pages docs site with Jekyll config and navigation
+* add overview, getting started, migration guide, and SEO checklist
+* add llms.txt and strengthen README/docs discoverability links
+
+### Metadata
+
+* expand PyPI metadata (keywords, classifiers, documentation URL)
+
 ## [0.19.2](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v0.19.0...v0.19.2) (2025-12-28)
 
 ### Documentation

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -60,7 +60,7 @@ try:
 except ImportError:  # pragma: no cover - fallback for older SQLAlchemy
     PGExecutionContext = DefaultExecutionContext
 
-__version__ = "0.19.2"
+__version__ = "0.19.3"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "0.19.2"
+version = "0.19.3"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},


### PR DESCRIPTION
## Summary
- bump version to 0.19.3
- update changelog for docs site and metadata

## Testing
- pre-commit (ty, ruff, ruff-format)