### PR TITLE
chore: release 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ preserved from the upstream project for historical context.
 
 ## Maintained in this fork
 
+## [1.4.3](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v0.19.3...v1.4.3) (2026-01-15)
+
+### Versioning
+
+* align package version with supported DuckDB version (1.4.x)
+* this release contains no functional changes from 0.19.3
+
 ## [0.19.3](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v0.19.2...v0.19.3) (2025-12-28)
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "0.19.3"
+version = "1.4.3"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},


### PR DESCRIPTION
## Summary

- Align package version with supported DuckDB version (1.4.x)
- This release contains no functional changes from 0.19.3

## Motivation

The package version is now aligned with the latest supported DuckDB version to make it clearer which DuckDB versions are supported by this dialect.

## Test plan

- [ ] Verify CI passes
- [ ] Merge and tag v1.4.3