### PR TITLE
docs: warn about multiprocessing fork

### DIFF
--- a/docs/motherduck.md
+++ b/docs/motherduck.md
@@ -41,6 +41,13 @@ engine = create_engine(
 )
 ```
 
+## Multiprocessing (fork)
+
+DuckDB's Python client is not fork-safe, so `multiprocessing` children created with
+`fork` can fail when opening new connections (commonly observed with MotherDuck or
+file-backed databases). Use the `spawn` or `forkserver` start methods and create
+engines/connections inside the child process.
+
 ## Options
 
 ### Connection-string parameters (instance cache key)

--- a/docs/types-and-caveats.md
+++ b/docs/types-and-caveats.md
@@ -87,3 +87,11 @@ users = Table(
 ## Pandas chunksize
 
 Older DuckDB versions (< 0.5.0) may have issues with `pandas.read_sql(..., chunksize=...)`. If you hit errors, use `chunksize=None` or upgrade DuckDB.
+
+## Multiprocessing (fork)
+
+DuckDB's Python bindings are not fork-safe. Creating a new connection in a
+`multiprocessing` child process created with `fork` can raise runtime errors
+(for example, `RuntimeError: thread::join failed: No such process`), especially
+with MotherDuck or file-backed connections. Prefer `spawn` or `forkserver`, and
+initialize engines/connections in the child process.


### PR DESCRIPTION
## Summary
- document DuckDB fork-safety caveat for multiprocessing
- note spawn/forkserver workaround in MotherDuck and caveats docs

## Testing
- pre-commit run --all-files