### PR TITLE
chore: release 1.4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ preserved from the upstream project for historical context.
 
 ## Maintained in this fork
 
+## [1.4.4.1](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.4.4...v1.4.4.1) (2026-02-05)
+
+### Documentation
+
+* document DuckDB multiprocessing fork-safety caveat and `spawn`/`forkserver` workaround
+
 ## [1.4.4](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.4.3...v1.4.4) (2026-02-03)
 
 ### Versioning

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -60,7 +60,7 @@ try:
 except ImportError:  # pragma: no cover - fallback for older SQLAlchemy
     PGExecutionContext = DefaultExecutionContext
 
-__version__ = "1.4.4"
+__version__ = "1.4.4.1"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.4.4"
+version = "1.4.4.1"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},


### PR DESCRIPTION
## Summary
- bump version to 1.4.4.1
- add changelog entry for multiprocessing fork caveat docs

## Testing
- pre-commit run --all-files