### PR TITLE
[codex] Fix datatypes null map handling and USMALLINT range

### DIFF
--- a/duckdb_sqlalchemy/datatypes.py
+++ b/duckdb_sqlalchemy/datatypes.py
@@ -69,7 +69,7 @@ class USmallInteger(DuckDBInteger):
     "AKA UInt2"
     # USMALLINT	-	0	65535
     min = 0
-    max = 2**15
+    max = 2**16 - 1
 
 
 class UBigInteger(DuckDBInteger):
@@ -204,9 +204,13 @@ class Map(TypeEngine):
         if IS_GT_1:
             return lambda value: value
         else:
-            return (
-                lambda value: dict(zip(value["key"], value["value"])) if value else {}
-            )
+
+            def _convert(value: Any) -> Optional[Dict[Any, Any]]:
+                if value is None:
+                    return None
+                return dict(zip(value["key"], value["value"]))
+
+            return _convert
 
 
 class Union(TypeEngine):


### PR DESCRIPTION
## Summary
This PR fixes two datatype correctness issues in `duckdb_sqlalchemy/datatypes.py`.

The first issue was an incorrect numeric bound for `USmallInteger`: the class advertised DuckDB `USMALLINT` but used `2**15` as the upper bound, which is `32768`. DuckDB `USMALLINT` is a 16-bit unsigned integer (`0..65535`). This mismatch could mislead downstream validation or user expectations when inspecting type metadata.

The second issue affected `Map.result_processor` for older DuckDB versions (`<=1.0` compatibility path). `NULL` values were being coerced to `{}` because the processor used a truthiness check. That collapses the semantic difference between SQL `NULL` (missing value) and an empty map. The processor now returns `None` for `NULL` and still reconstructs non-null map payloads from DuckDB's key/value representation.

## User impact
Users relying on type metadata get a correct `USMALLINT` range value.

Users reading nullable `MAP` columns on the legacy conversion path now preserve `NULL` as `None` instead of receiving empty dictionaries, preventing data-shape ambiguity and logic bugs in ORM/application layers.

## Root cause
- `USmallInteger.max` used an incorrect power-of-two expression.
- `Map.result_processor` used `if value` instead of explicit `None` handling in the legacy branch.

## Fix
- Set `USmallInteger.max` to `2**16 - 1`.
- Replace legacy map conversion lambda with explicit conversion logic:
  - `None` -> `None`
  - non-null map payload -> `dict(zip(value["key"], value["value"]))`

## Validation
- Pre-commit hooks run during commit (with `ty` skipped due existing repo-wide baseline warnings).
- Targeted tests:
  - `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_datatypes.py`
  - Result: `20 passed, 2 skipped`.
