### PR TITLE
[codex] docs: refresh docs navigation and contributor workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Current direction in this repository:
 | Component | Supported versions |
 | --- | --- |
 | Python | 3.9+ |
-| SQLAlchemy | 1.3.22+ (2.x recommended) |
-| DuckDB | 1.3.0+ (1.4.4 recommended) |
+| SQLAlchemy | 1.3.22+ (CI-tested: 1.3, 1.4, 2.0.x) |
+| DuckDB | 0.5.0+ (CI-tested currently: 1.1.3 to 1.4.4) |
 
 ## Install
 
@@ -129,37 +129,58 @@ md_url = MotherDuckURL(database="md:my_db", attach_mode="single")
 
 This dialect defaults to `NullPool` for file/MotherDuck connections and `SingletonThreadPool` for `:memory:`. You can override pooling explicitly. For long-lived MotherDuck pools, use the performance helper or configure `QueuePool`, `pool_pre_ping`, and `pool_recycle`.
 
-See `docs/configuration.md` and `docs/motherduck.md` for detailed guidance.
+See [docs/configuration.md](docs/configuration.md) and
+[docs/motherduck.md](docs/motherduck.md) for detailed guidance.
 
 ## Documentation
 
-- `docs/index.md` - GitHub Pages entrypoint
-- `docs/README.md` - Docs index
-- `docs/overview.md` - Overview and quick start
-- `docs/getting-started.md` - Minimal install + setup walkthrough
-- `docs/migration-from-duckdb-engine.md` - Migration guide from older dialects
-- `docs/connection-urls.md` - URL formats and helpers
-- `docs/motherduck.md` - MotherDuck setup and options
-- `docs/configuration.md` - Connection configuration, extensions, filesystems
-- `docs/olap.md` - Parquet/CSV scans and ATTACH workflows
-- `docs/pandas-jupyter.md` - DataFrame registration and notebook usage
-- `docs/types-and-caveats.md` - Type support and known caveats
-- `docs/alembic.md` - Alembic integration
+- [docs/index.md](docs/index.md) - GitHub Pages entrypoint
+- [docs/README.md](docs/README.md) - Docs index
+- [docs/overview.md](docs/overview.md) - Overview and quick start
+- [docs/getting-started.md](docs/getting-started.md) - Minimal install + setup walkthrough
+- [docs/migration-from-duckdb-engine.md](docs/migration-from-duckdb-engine.md) - Migration guide from older dialects
+- [docs/connection-urls.md](docs/connection-urls.md) - URL formats and helpers
+- [docs/motherduck.md](docs/motherduck.md) - MotherDuck setup and options
+- [docs/configuration.md](docs/configuration.md) - Connection configuration, extensions, filesystems
+- [docs/olap.md](docs/olap.md) - Parquet/CSV scans and ATTACH workflows
+- [docs/pandas-jupyter.md](docs/pandas-jupyter.md) - DataFrame registration and notebook usage
+- [docs/types-and-caveats.md](docs/types-and-caveats.md) - Type support and known caveats
+- [docs/alembic.md](docs/alembic.md) - Alembic integration
 
 Docs site (GitHub Pages):
 
-```
-https://leonardovida.github.io/duckdb-sqlalchemy/
-```
+[https://leonardovida.github.io/duckdb-sqlalchemy/](https://leonardovida.github.io/duckdb-sqlalchemy/)
 
 ## Examples
 
-- `examples/sqlalchemy_example.py` - end-to-end example
-- `examples/motherduck_read_scaling_per_user.py` - per-user read scaling pattern
-- `examples/motherduck_queuepool_high_concurrency.py` - QueuePool tuning
-- `examples/motherduck_multi_instance_pool.py` - multi-instance pool rotation
-- `examples/motherduck_arrow_reads.py` - Arrow results + streaming
-- `examples/motherduck_attach_modes.py` - workspace vs single attach mode
+- [examples/sqlalchemy_example.py](examples/sqlalchemy_example.py) - end-to-end example
+- [examples/motherduck_read_scaling_per_user.py](examples/motherduck_read_scaling_per_user.py) - per-user read scaling pattern
+- [examples/motherduck_queuepool_high_concurrency.py](examples/motherduck_queuepool_high_concurrency.py) - QueuePool tuning
+- [examples/motherduck_multi_instance_pool.py](examples/motherduck_multi_instance_pool.py) - multi-instance pool rotation
+- [examples/motherduck_arrow_reads.py](examples/motherduck_arrow_reads.py) - Arrow results + streaming
+- [examples/motherduck_attach_modes.py](examples/motherduck_attach_modes.py) - workspace vs single attach mode
+
+## Development workflow
+
+Install development dependencies:
+
+```sh
+pip install -e ".[dev,devtools]"
+```
+
+Run quick checks in your current environment:
+
+```sh
+pytest
+nox -s ty
+pre-commit run --all-files
+```
+
+Run the full compatibility matrix (slow):
+
+```sh
+nox -s tests
+```
 
 ## Release and support policy
 
@@ -170,13 +191,14 @@ https://leonardovida.github.io/duckdb-sqlalchemy/
 
 ## Changelog and roadmap
 
-- `CHANGELOG.md` - release notes
-- `ROADMAP.md` - upcoming work and priorities
+- [CHANGELOG.md](CHANGELOG.md) - release notes
+- [ROADMAP.md](ROADMAP.md) - upcoming work and priorities
 
 ## Contributing
 
-See `AGENTS.md` for repo-specific workflow, tooling, and PR expectations. We welcome issues, bug reports, and high-quality pull requests.
+See [AGENTS.md](AGENTS.md) for repo-specific workflow, tooling, and PR
+expectations. We welcome issues, bug reports, and high-quality pull requests.
 
 ## License
 
-MIT. See `LICENSE.txt`.
+MIT. See [LICENSE.txt](LICENSE.txt).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,23 +4,25 @@ This folder contains focused, task-oriented guides that keep the main README sho
 
 ## Guides
 
-- `overview.md` - High-level overview and quick start
-- `getting-started.md` - Minimal install + setup walkthrough
-- `migration-from-duckdb-engine.md` - Migration guide from older dialects
-- `connection-urls.md` - URL formats, helpers, and manual escaping
-- `motherduck.md` - Connection patterns and MotherDuck-specific options
-- `configuration.md` - `connect_args`, extension preloads, and filesystem registration
-- `olap.md` - Table functions (`read_parquet`, `read_csv_auto`) and ATTACH examples
-- `pandas-jupyter.md` - DataFrame registration and notebook usage
-- `types-and-caveats.md` - Supported types, parameter binding, and gotchas
-- `alembic.md` - Alembic integration notes
-- `seo-checklist.md` - Docs indexability checklist
+- [overview.md](overview.md) - High-level overview and quick start
+- [getting-started.md](getting-started.md) - Minimal install + setup walkthrough
+- [migration-from-duckdb-engine.md](migration-from-duckdb-engine.md) - Migration guide from older dialects
+- [connection-urls.md](connection-urls.md) - URL formats, helpers, and manual escaping
+- [motherduck.md](motherduck.md) - Connection patterns and MotherDuck-specific options
+- [configuration.md](configuration.md) - `connect_args`, extension preloads, and filesystem registration
+- [olap.md](olap.md) - Table functions (`read_parquet`, `read_csv_auto`) and ATTACH examples
+- [pandas-jupyter.md](pandas-jupyter.md) - DataFrame registration and notebook usage
+- [types-and-caveats.md](types-and-caveats.md) - Supported types, parameter binding, and gotchas
+- [alembic.md](alembic.md) - Alembic integration notes
+- [seo-checklist.md](seo-checklist.md) - Docs indexability checklist
 
 ## Project references
 
-- `../CHANGELOG.md` - Release notes
-- `../ROADMAP.md` - Dialect upgrade roadmap and PR checklists
+- [../CHANGELOG.md](../CHANGELOG.md) - Release notes
+- [../ROADMAP.md](../ROADMAP.md) - Dialect upgrade roadmap and PR checklists
 
 ## Examples
 
-The `examples/` directory contains runnable scripts. If you want a full end-to-end walkthrough, start with `examples/sqlalchemy_example.py`.
+The `examples/` directory contains runnable scripts. If you want a full
+end-to-end walkthrough, start with
+[examples/sqlalchemy_example.py](../examples/sqlalchemy_example.py).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,16 @@ If you supply a setting in both the URL and `connect_args["config"]`, the URL va
 engine = create_engine("duckdb:///analytics.db", connect_args={"read_only": True})
 ```
 
+## Validation and error behavior
+
+- Config key names are identifier-validated before `SET` statements are emitted.
+  SQL fragments or punctuation in key names are rejected with `ValueError`.
+- Unknown but syntactically valid keys are forwarded to DuckDB and may fail with
+  DuckDB's native "unrecognized configuration parameter" error.
+- MotherDuck path-query options (`attach_mode`, `session_hint`, `access_mode`,
+  and related keys) are handled specially for `md:` URLs. See
+  [motherduck.md](motherduck) and [connection-urls.md](connection-urls).
+
 ## Preload extensions
 
 DuckDB can auto-install and auto-load extensions. You can preload extensions during connection:

--- a/docs/connection-urls.md
+++ b/docs/connection-urls.md
@@ -63,6 +63,25 @@ url = URL(database=":memory:", memory_limit="1GB")
 engine = create_engine(url)
 ```
 
+## MotherDuck URL helper
+
+Use `MotherDuckURL` when you want routing/instance-cache params to live in the
+database path and config params in the regular URL query:
+
+```python
+from sqlalchemy import create_engine
+from duckdb_sqlalchemy import MotherDuckURL
+
+url = MotherDuckURL(
+    database="md:my_db",
+    attach_mode="single",
+    access_mode="read_only",
+    session_hint="team-a",
+    query={"memory_limit": "1GB"},
+)
+engine = create_engine(url)
+```
+
 ## Manual escaping
 
 If you build URLs manually and your token contains special characters, escape it:
@@ -76,8 +95,10 @@ escaped = quote_plus(os.environ["MOTHERDUCK_TOKEN"])
 engine = create_engine(f"duckdb:///md:my_db?motherduck_token={escaped}")
 ```
 
-See `motherduck.md` for MotherDuck-specific examples and options.
+See [motherduck.md](motherduck) for MotherDuck-specific examples and options.
 
 ## Pool defaults
 
-Pooling behavior is described in `configuration.md` (NullPool for file/MotherDuck, SingletonThreadPool for `:memory:`) and can be overridden with `poolclass`.
+Pooling behavior is described in [configuration.md](configuration)
+(NullPool for file/MotherDuck, SingletonThreadPool for `:memory:`) and can be
+overridden with `poolclass`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,7 +75,7 @@ duckdb:///md:my_db?attach_mode=single&access_mode=read_only&session_hint=team-a
 
 ## Next steps
 
-- Connection strings: `docs/connection-urls.md`
-- MotherDuck options: `docs/motherduck.md`
-- Configuration and pooling: `docs/configuration.md`
-- OLAP helpers: `docs/olap.md`
+- [Connection strings](connection-urls)
+- [MotherDuck options](motherduck)
+- [Configuration and pooling](configuration)
+- [OLAP helpers](olap)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,4 +23,5 @@ Production-ready DuckDB SQLAlchemy dialect for DuckDB and MotherDuck.
 
 ## Examples
 
-See `examples/` in the repository for runnable scripts.
+See [examples/](https://github.com/leonardovida/duckdb-sqlalchemy/tree/main/examples)
+for runnable scripts.

--- a/docs/migration-from-duckdb-engine.md
+++ b/docs/migration-from-duckdb-engine.md
@@ -27,5 +27,6 @@ SQLAlchemy URLs use the `duckdb://` driver name in both packages. Existing URLs 
 
 - The package name is now `duckdb-sqlalchemy` and the module is `duckdb_sqlalchemy`.
 - The dialect remains registered as `duckdb` for SQLAlchemy.
-- See `docs/motherduck.md` for MotherDuck-specific behavior.
-- See `README.md` for project lineage, release policy, and roadmap links.
+- See [motherduck.md](motherduck) for MotherDuck-specific behavior.
+- See [README.md](../README.md) for project lineage, release policy, and
+  roadmap links.

--- a/docs/olap.md
+++ b/docs/olap.md
@@ -117,6 +117,9 @@ For safety, string table names, column names, and COPY option keys must be
 identifiers. Dotted paths like `schema.events` are supported, but SQL
 fragments are rejected.
 
+If you need quoted or mixed-case identifiers, pass a SQLAlchemy `Table` object
+instead of a plain string so SQLAlchemy handles quoting.
+
 For row iterables, you can stream to a temporary CSV in chunks:
 
 ```python

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,7 +37,7 @@ with Session(engine) as session:
 
 ## Next steps
 
-- Connection strings: `docs/connection-urls.md`
-- MotherDuck usage: `docs/motherduck.md`
-- Configuration and pooling: `docs/configuration.md`
-- OLAP helpers: `docs/olap.md`
+- [Connection strings](connection-urls)
+- [MotherDuck usage](motherduck)
+- [Configuration and pooling](configuration)
+- [OLAP helpers](olap)


### PR DESCRIPTION
## Summary
The documentation set had drifted into a mixed navigation style: several files used inline code-style path references instead of clickable links, cross-page links in Jekyll pages pointed to repository paths instead of site-relative routes, and contributor workflow guidance in the root README did not reflect the practical commands maintainers use day to day. This made docs harder to navigate both on GitHub and on the published Pages site.

## User impact and root cause
For users reading the docs through GitHub Pages, some "next steps" paths were not rendered as first-class links and required manual path reconstruction. For contributors onboarding through the repository README, development commands and compatibility expectations were less explicit than the current workflow. The underlying cause was incremental documentation growth across files without a consistent linking and contributor-guidance pass after recent project changes.

## What this PR changes
This PR standardizes docs navigation across README and docs pages by converting path mentions to clickable links where appropriate, updates internal doc cross-links to site-friendly relative routes, and adds a clearer development workflow section to the root README. It also extends configuration and connection URL docs with concise guidance around validation behavior and MotherDuck URL helper usage, and clarifies COPY helper behavior for quoted or mixed-case identifiers.

## Validation
I ran `pre-commit run --all-files` before finalizing. It fails due existing repository-wide `ty` diagnostics in Python sources outside this docs-only diff. I then validated the docs edits with the remaining pre-commit hooks (`end-of-file-fixer`, `trailing-whitespace`) and completed the branch commit with `SKIP=ty` for this docs-focused PR.
