### PR TITLE
[codex] consolidate motherduck ttl alias normalization

### DIFF
--- a/duckdb_sqlalchemy/motherduck.py
+++ b/duckdb_sqlalchemy/motherduck.py
@@ -53,32 +53,30 @@ def _warn_deprecated_ttl_alias() -> None:
     )
 
 
-def _sync_ttl_alias(
+def _normalize_ttl_alias(
     values: Dict[str, Any],
     *,
-    source_key: str,
-    target_key: str,
+    canonical_key: str,
+    alias_key: str,
     warn_on_key: str,
-    drop_source: bool = False,
+    drop_alias: bool = False,
 ) -> Dict[str, Any]:
     if warn_on_key in values:
         _warn_deprecated_ttl_alias()
 
-    source_value = (
-        values.pop(source_key, None) if drop_source else values.get(source_key)
-    )
-    if target_key not in values and source_value is not None:
-        values[target_key] = source_value
+    alias_value = values.pop(alias_key, None) if drop_alias else values.get(alias_key)
+    if canonical_key not in values and alias_value is not None:
+        values[canonical_key] = alias_value
     return values
 
 
 def _normalize_path_query_aliases(path_query: Dict[str, Any]) -> Dict[str, Any]:
-    return _sync_ttl_alias(
+    return _normalize_ttl_alias(
         path_query,
-        source_key=MOTHERDUCK_DBINSTANCE_INACTIVITY_TTL_KEY,
-        target_key=DBINSTANCE_INACTIVITY_TTL_KEY,
+        canonical_key=DBINSTANCE_INACTIVITY_TTL_KEY,
+        alias_key=MOTHERDUCK_DBINSTANCE_INACTIVITY_TTL_KEY,
         warn_on_key=MOTHERDUCK_DBINSTANCE_INACTIVITY_TTL_KEY,
-        drop_source=True,
+        drop_alias=True,
     )
 
 
@@ -89,10 +87,10 @@ def _normalize_path_query_mapping(
 
 
 def _normalize_config_aliases(config: Dict[str, Any]) -> Dict[str, Any]:
-    return _sync_ttl_alias(
+    return _normalize_ttl_alias(
         config,
-        source_key=DBINSTANCE_INACTIVITY_TTL_KEY,
-        target_key=MOTHERDUCK_DBINSTANCE_INACTIVITY_TTL_KEY,
+        canonical_key=MOTHERDUCK_DBINSTANCE_INACTIVITY_TTL_KEY,
+        alias_key=DBINSTANCE_INACTIVITY_TTL_KEY,
         warn_on_key=MOTHERDUCK_DBINSTANCE_INACTIVITY_TTL_KEY,
     )
 


### PR DESCRIPTION
This change is a small targeted refactor in the MotherDuck URL/config normalization path.

The issue is not a user-visible bug but a maintenance risk in the TTL alias handling logic. The code had one shared helper with source/target terminology that had to encode two different directions of behavior: path query normalization and config normalization. Those call sites were semantically different enough that the helper API made the intent harder to read and easier to misuse during future edits.

The practical effect of that ambiguity is that a seemingly harmless cleanup can accidentally change warning behavior or alias precedence for MotherDuck TTL settings. That would be easy to miss because the path query and config cases copy values in different directions while still warning on the deprecated MotherDuck key.

The root cause was an underspecified helper interface. `_sync_ttl_alias` described the data flow mechanically, but it did not communicate which key is canonical, which key is treated as the alias, or that the warning key can differ from the copied key.

The fix is to keep the shared helper but rename and reshape it around the actual rule being applied. `_normalize_ttl_alias` now takes explicit `canonical_key`, `alias_key`, and `warn_on_key` parameters, with `drop_alias` covering the path-query case. The two call sites now read directly in terms of their intent while preserving the exact warning and precedence behavior covered by the test suite.

Validation used the existing focused unit coverage for MotherDuck helpers and URL/config behavior:

- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py duckdb_sqlalchemy/tests/test_helpers.py`
- `uv run --extra dev python -m compileall duckdb_sqlalchemy`
