### PR TITLE
chore: release 1.5.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ preserved from the upstream project for historical context.
 
 ## Unreleased
 
+## [1.5.1.4](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.1.3...v1.5.1.4) (2026-04-10)
+
+### Versioning
+
+- release 1.5.1.4 with no runtime code changes; this cut only updates package metadata and triggers the GitHub release workflow
+
 ## [1.5.1.3](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.1.2...v1.5.1.3) (2026-04-10)
 
 ### Bug Fixes

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -68,7 +68,7 @@ else:
         _pg_base, "PGExecutionContext", DefaultExecutionContext
     )
 
-__version__ = "1.5.1.3"
+__version__ = "1.5.1.4"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.1.3"
+version = "1.5.1.4"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},


### PR DESCRIPTION
## What changed
- bump the package version to 1.5.1.4 in project metadata and the exported `__version__`
- add the 1.5.1.4 changelog entry for this metadata-only release cut

## Validation
- `pre-commit run --files pyproject.toml duckdb_sqlalchemy/__init__.py CHANGELOG.md`