### PR TITLE
[codex] refactor duckdb reflection filters

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -956,16 +956,12 @@ class Dialect(PGDialect_psycopg2):
         sql = """
             SELECT 1
             FROM duckdb_tables()
-            WHERE table_name = :table_name
+            WHERE 1 = 1
             """
-        params: Dict[str, Any] = {"table_name": table_name}
-        if schema is not None:
-            database_name, schema_name = self.identifier_preparer._separate(schema)
-            sql += "AND schema_name = :schema_name\n"
-            params["schema_name"] = schema_name
-            if database_name is not None:
-                sql += "AND database_name = :database_name\n"
-                params["database_name"] = database_name
+        where_sql, params = self._build_query_where(
+            table_name=table_name, schema_name=schema
+        )
+        sql += where_sql
         return connection.execute(text(sql), params).first() is not None
 
     def _duckdb_columns(
@@ -995,12 +991,9 @@ class Dialect(PGDialect_psycopg2):
         if include_internal_filter:
             sql += "AND internal = false\n"
         if schema is not None:
-            database_name, schema_name = self.identifier_preparer._separate(schema)
-            sql += "AND schema_name = :schema_name\n"
-            params["schema_name"] = schema_name
-            if database_name is not None:
-                sql += "AND database_name = :database_name\n"
-                params["database_name"] = database_name
+            where_sql, where_params = self._build_query_where(schema_name=schema)
+            sql += where_sql
+            params.update(where_params)
         if filter_names is not None:
             names = list(filter_names)
             if not names:

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -1,6 +1,6 @@
 import warnings
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Optional, cast
 from urllib.parse import parse_qs
 
 import duckdb
@@ -623,6 +623,57 @@ def test_struct_or_union_requires_fields() -> None:
     assert rendered.startswith("(")
     assert rendered.endswith(")")
     assert '"first name"' in rendered
+
+
+def test_duckdb_reflection_filters_share_schema_database_builder() -> None:
+    dialect = Dialect()
+
+    stmt, params = dialect._duckdb_reflection_stmt(
+        "duckdb_tables",
+        "table_name",
+        schema='"analytics db"."reporting"',
+        filter_names=["orders"],
+        include_internal_filter=True,
+    )
+
+    assert "AND internal = false" in stmt.text
+    assert "AND schema_name = :schema_name" in stmt.text
+    assert "AND database_name = :database_name" in stmt.text
+    assert "AND table_name IN :filter_names" in stmt.text
+    assert params == {
+        "schema_name": "reporting",
+        "database_name": "analytics db",
+        "filter_names": ["orders"],
+    }
+
+    class DummyResult:
+        def first(self) -> tuple[int]:
+            return (1,)
+
+    class DummyConnection:
+        def __init__(self) -> None:
+            self.statement: Any = None
+            self.params: Optional[dict[str, Any]] = None
+
+        def execute(self, statement: Any, params: dict[str, Any]) -> DummyResult:
+            self.statement = statement
+            self.params = params
+            return DummyResult()
+
+    connection = DummyConnection()
+
+    assert dialect._duckdb_table_exists(
+        cast(Any, connection), "orders", '"analytics db"."reporting"'
+    )
+    assert connection.statement is not None
+    assert "AND table_name = :table_name" in connection.statement.text
+    assert "AND schema_name = :schema_name" in connection.statement.text
+    assert "AND database_name = :database_name" in connection.statement.text
+    assert connection.params == {
+        "table_name": "orders",
+        "schema_name": "reporting",
+        "database_name": "analytics db",
+    }
 
 
 def test_parse_duckdb_enum_labels_unquotes_escaped_strings() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.1.3"
+version = "1.5.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## What changed

This PR keeps the refactor intentionally small: DuckDB reflection code now reuses the dialect's existing `_build_query_where` helper when adding table, schema, and database filters. `_duckdb_table_exists` no longer carries a separate hand-built copy of the same table/schema/database predicate logic, and `_duckdb_reflection_stmt` now delegates its schema/database filter construction to the same helper as the older table-name reflection paths.

The user-visible behavior should be unchanged. The main effect is reducing duplicated reflection SQL construction so database-qualified schemas keep a single normalization path through `DuckDBIdentifierPreparer._separate`.

While setting up the local test environment with `uv sync`, the lockfile also updated the editable project entry from `1.5.1.3` to the repo's current `1.5.1.4`; this does not release or bump a new version.

## Validation

- `uv run pytest duckdb_sqlalchemy/tests/test_core_units.py -q`
- `uv run pre-commit run --all-files`
- `uv run pytest -q`

The focused unit coverage now asserts that `_duckdb_reflection_stmt` and `_duckdb_table_exists` both produce the same schema/database filter shape for database-qualified schemas.
