### PR TITLE
[codex] refactor duckdb reflection statements

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -981,6 +981,7 @@ class Dialect(PGDialect_psycopg2):
         schema: Optional[str] = None,
         filter_names: Optional[Collection[str]] = None,
         include_internal_filter: bool = False,
+        suffix: str = "",
     ) -> Tuple[Any, Dict[str, Any]]:
         sql = f"""
             SELECT {columns}
@@ -1001,6 +1002,8 @@ class Dialect(PGDialect_psycopg2):
             else:
                 sql += "AND table_name IN :filter_names\n"
                 params["filter_names"] = names
+        if suffix:
+            sql += suffix
         stmt = text(sql)
         if params.get("filter_names"):
             stmt = stmt.bindparams(bindparam("filter_names", expanding=True))
@@ -1021,11 +1024,8 @@ class Dialect(PGDialect_psycopg2):
             schema=schema,
             filter_names=filter_names,
             include_internal_filter=True,
+            suffix="ORDER BY table_name, column_index",
         )
-        sql = f"{stmt.text}ORDER BY table_name, column_index"
-        stmt = text(sql)
-        if params.get("filter_names"):
-            stmt = stmt.bindparams(bindparam("filter_names", expanding=True))
         return [dict(row) for row in connection.execute(stmt, params).mappings()]
 
     def _duckdb_table_names(
@@ -1040,11 +1040,8 @@ class Dialect(PGDialect_psycopg2):
             schema=schema,
             filter_names=filter_names,
             include_internal_filter=True,
+            suffix="ORDER BY table_name",
         )
-        sql = f"{stmt.text}ORDER BY table_name"
-        stmt = text(sql)
-        if params.get("filter_names"):
-            stmt = stmt.bindparams(bindparam("filter_names", expanding=True))
         return [row[0] for row in connection.execute(stmt, params)]
 
     def _duckdb_enum_rows(
@@ -1304,11 +1301,11 @@ class Dialect(PGDialect_psycopg2):
             "table_name, constraint_name, constraint_column_names",
             schema=schema,
             filter_names=filter_names,
+            suffix=(
+                "AND constraint_type = 'PRIMARY KEY'\n"
+                "ORDER BY table_name, constraint_index"
+            ),
         )
-        sql = f"{stmt.text}AND constraint_type = 'PRIMARY KEY'\nORDER BY table_name, constraint_index"
-        stmt = text(sql)
-        if params.get("filter_names"):
-            stmt = stmt.bindparams(bindparam("filter_names", expanding=True))
         constraint_rows = list(connection.execute(stmt, params).mappings())
         constraints = {
             row["table_name"]: {
@@ -1426,11 +1423,8 @@ class Dialect(PGDialect_psycopg2):
             "table_name, index_name, expressions, is_unique",
             schema=schema,
             filter_names=filter_names,
+            suffix="ORDER BY table_name, index_name",
         )
-        sql = f"{stmt.text}ORDER BY table_name, index_name"
-        stmt = text(sql)
-        if params.get("filter_names"):
-            stmt = stmt.bindparams(bindparam("filter_names", expanding=True))
         index_rows = list(connection.execute(stmt, params).mappings())
         indexes: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
         for row in index_rows:

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -646,6 +646,17 @@ def test_duckdb_reflection_filters_share_schema_database_builder() -> None:
         "filter_names": ["orders"],
     }
 
+    ordered_stmt, ordered_params = dialect._duckdb_reflection_stmt(
+        "duckdb_tables",
+        "table_name",
+        filter_names=["orders"],
+        suffix="ORDER BY table_name",
+    )
+
+    assert ordered_stmt.text.rstrip().endswith("ORDER BY table_name")
+    assert ordered_params == {"filter_names": ["orders"]}
+    assert ordered_stmt._bindparams["filter_names"].expanding
+
     class DummyResult:
         def first(self) -> tuple[int]:
             return (1,)


### PR DESCRIPTION
## Issue
DuckDB reflection helpers were each rebuilding a SQLAlchemy `TextClause` after appending ordering or extra predicates, then repeating the same expanding `filter_names` bind parameter setup. That made the reflection query path harder to maintain because changes to bind handling had to be mirrored across several callers.

## Cause and effect
The shared `_duckdb_reflection_stmt` helper built the base reflection query and handled schema/table filters, but callers that needed an `ORDER BY` or a final primary-key predicate appended raw SQL afterward. Reconstructing the statement outside the helper duplicated the binding logic and made it easier for future changes to accidentally leave one reflection path inconsistent.

## Fix
This refactor lets `_duckdb_reflection_stmt` accept an optional SQL suffix. The helper now appends caller-specific suffixes before creating the `TextClause`, so it remains the single place that wires expanding `filter_names` parameters. Column, table-name, primary-key, and index reflection callers now pass only their suffix instead of rebuilding statements locally.

## Validation
- `uv run --extra dev --extra devtools pytest duckdb_sqlalchemy/tests/test_core_units.py -q`
- `uv run --extra dev --extra devtools pre-commit run --all-files`
- `uv run --extra dev --extra devtools pytest -q`
