### PR TITLE
[codex] refactor reflection fallback

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -1238,6 +1238,34 @@ class Dialect(PGDialect_psycopg2):
     def _reflection_schema_key(self, schema: Optional[str]) -> Optional[str]:
         return schema
 
+    def _get_single_reflection_result(
+        self,
+        connection: "Connection",
+        table_name: str,
+        schema: Optional[str],
+        get_multi: Any,
+        default_factory: Any,
+        **kw: Any,
+    ) -> Any:
+        scope = kw.pop("scope", None)
+        kind = kw.pop("kind", None)
+        reflected = dict(
+            get_multi(
+                connection,
+                schema=schema,
+                filter_names=[table_name],
+                scope=scope,
+                kind=kind,
+                **kw,
+            )
+        )
+        key = (self._reflection_schema_key(schema), table_name)
+        if key in reflected:
+            return reflected[key]
+        if self._duckdb_table_exists(connection, table_name, schema):
+            return default_factory()
+        raise NoSuchTableError(table_name)
+
     def has_table(
         self,
         connection: "Connection",
@@ -1267,24 +1295,14 @@ class Dialect(PGDialect_psycopg2):
         schema: Optional[str] = None,
         **kw: Any,
     ) -> "ReflectedPrimaryKeyConstraint":
-        scope = kw.pop("scope", None)
-        kind = kw.pop("kind", None)
-        constraints = dict(
-            self.get_multi_pk_constraint(
-                connection,
-                schema=schema,
-                filter_names=[table_name],
-                scope=scope,
-                kind=kind,
-                **kw,
-            )
+        return self._get_single_reflection_result(
+            connection,
+            table_name,
+            schema,
+            self.get_multi_pk_constraint,
+            ReflectionDefaults.pk_constraint,
+            **kw,
         )
-        key = (self._reflection_schema_key(schema), table_name)
-        if key in constraints:
-            return constraints[key]
-        if self._duckdb_table_exists(connection, table_name, schema):
-            return ReflectionDefaults.pk_constraint()
-        raise NoSuchTableError(table_name)
 
     def get_multi_pk_constraint(
         self,
@@ -1388,24 +1406,14 @@ class Dialect(PGDialect_psycopg2):
         schema: Optional[str] = None,
         **kw: Any,
     ) -> List["ReflectedIndex"]:  # type: ignore[override]
-        scope = kw.pop("scope", None)
-        kind = kw.pop("kind", None)
-        indexes = dict(
-            self.get_multi_indexes(
-                connection,
-                schema=schema,
-                filter_names=[table_name],
-                scope=scope,
-                kind=kind,
-                **kw,
-            )
+        return self._get_single_reflection_result(
+            connection,
+            table_name,
+            schema,
+            self.get_multi_indexes,
+            ReflectionDefaults.indexes,
+            **kw,
         )
-        key = (self._reflection_schema_key(schema), table_name)
-        if key in indexes:
-            return indexes[key]
-        if self._duckdb_table_exists(connection, table_name, schema):
-            return ReflectionDefaults.indexes()
-        raise NoSuchTableError(table_name)
 
     # the following methods are for SQLA2 compatibility
     def get_multi_indexes(

--- a/duckdb_sqlalchemy/tests/test_basic.py
+++ b/duckdb_sqlalchemy/tests/test_basic.py
@@ -31,10 +31,10 @@ from sqlalchemy import (
     text,
     types,
 )
-from sqlalchemy.dialects import registry  # type: ignore
+from sqlalchemy.dialects import registry
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.engine.reflection import Inspector
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.orm import Session, declarative_base, relationship, sessionmaker
 from sqlalchemy.pool import QueuePool, SingletonThreadPool
 
@@ -465,7 +465,7 @@ def test_sessions(session: Session) -> None:
 
     c2 = session.get(IntervalModel, 1)
     assert c2
-    c2.field = timedelta(days=5)
+    cast(Any, c2).field = timedelta(days=5)
     session.flush()
     session.commit()
 
@@ -575,7 +575,7 @@ def test_do_ping(tmp_path: Path, caplog: LogCaptureFixture) -> None:
         poolclass=QueuePool,
     )
 
-    logger = cast(logging.Logger, engine.pool.logger)  # type: ignore
+    logger = cast(logging.Logger, engine.pool.logger)
     logger.setLevel(logging.DEBUG)
 
     with caplog.at_level(logging.DEBUG, logger=logger.name):
@@ -637,7 +637,7 @@ def test_checkpoint_helper_without_commit_preserves_checkpoint_failure(
         conn.execute(text("create table t(i int)"))
         conn.execute(text("insert into t values (1)"))
 
-        with raises(sqlalchemy.exc.OperationalError):
+        with raises(OperationalError):
             checkpoint(conn, commit=False)
 
         conn.rollback()

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -1,6 +1,6 @@
 import warnings
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, Optional, Tuple, cast
 from urllib.parse import parse_qs
 
 import duckdb
@@ -499,8 +499,8 @@ def test_engine_connect_does_not_probe_isolation_level(
     def tracked_execute(
         self: CursorWrapper,
         statement: str,
-        parameters: tuple[Any, ...] | None = None,
-        context: Any | None = None,
+        parameters: Optional[Tuple[Any, ...]] = None,
+        context: Optional[Any] = None,
     ) -> None:
         calls.append(statement)
         return original_execute(self, statement, parameters, context)
@@ -539,7 +539,7 @@ def test_cursorwrapper_executemany_coerces_to_list() -> None:
     cursor = _cursor(conn)
     params = ({"a": 1}, {"a": 2})
 
-    cursor.executemany("insert", params)  # type: ignore[arg-type]
+    cursor.executemany("insert", cast(Any, params))
 
     assert conn.calls[0][0] == "insert"
     assert conn.calls[0][1] == list(params)
@@ -627,10 +627,10 @@ def test_struct_or_union_requires_fields() -> None:
     preparer = dialect.identifier_preparer
 
     with pytest.raises(sa_exc.CompileError):
-        dt.struct_or_union(dt.Struct(), cast(Any, compiler), preparer)
+        dt.struct_or_union(dt.Struct(), compiler, preparer)
 
     struct = dt.Struct({"first name": String, "age": Integer})
-    rendered = dt.struct_or_union(struct, cast(Any, compiler), preparer)
+    rendered = dt.struct_or_union(struct, compiler, preparer)
     assert rendered.startswith("(")
     assert rendered.endswith(")")
     assert '"first name"' in rendered

--- a/duckdb_sqlalchemy/tests/test_pandas.py
+++ b/duckdb_sqlalchemy/tests/test_pandas.py
@@ -10,7 +10,7 @@ import random
 from collections import OrderedDict
 from datetime import datetime, timezone
 from itertools import product
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import Dict, List, Literal, Optional, Tuple, Union, cast
 
 import pandas as pd
 from pandas.testing import assert_frame_equal
@@ -37,9 +37,7 @@ args = {
     "read_sql": ["chunksize"],
 }
 params = {
-    k: list(
-        product(*(_v for _k, _v in _possible_args.items() if _k in args[k]))  # type: ignore
-    )
+    k: list(product(*(_v for _k, _v in _possible_args.items() if _k in args[k])))
     for k in args
 }
 params_strings = {k: (",".join([str(_k) for _k in args[k]])) for k in args}
@@ -68,7 +66,7 @@ sample_df: pd.DataFrame = pd.DataFrame(sample_data)
 @mark.parametrize(params_strings["to_sql"], params["to_sql"])
 def test_to_sql(
     chunksize: Optional[int],
-    if_exists: str,
+    if_exists: Literal["fail", "replace", "append"],
     method: Optional[str],
     index: bool = False,
 ) -> None:

--- a/duckdb_sqlalchemy/tests/test_pyarrow.py
+++ b/duckdb_sqlalchemy/tests/test_pyarrow.py
@@ -1,15 +1,17 @@
+from typing import Any, Optional, cast
+
 from pyarrow import RecordBatch, RecordBatchReader
 from pyarrow import Table as ArrowTable
 from sqlalchemy import MetaData, Table, create_engine, text
 
 
-def _to_arrow_table(cursor):
+def _to_arrow_table(cursor: Any) -> Any:
     if hasattr(cursor, "to_arrow_table"):
         return cursor.to_arrow_table()
     return cursor.fetch_arrow_table()
 
 
-def _to_arrow_reader(cursor, batch_size=None):
+def _to_arrow_reader(cursor: Any, batch_size: Optional[int] = None) -> Any:
     if hasattr(cursor, "to_arrow_reader"):
         if batch_size is None:
             return cursor.to_arrow_reader()
@@ -35,7 +37,9 @@ def test_fetch_arrow() -> None:
 
     # rows
     with engine.begin() as con:
-        res = con.execute(stmt).cursor.fetchall()
+        cursor = con.execute(stmt).cursor
+        assert cursor is not None
+        res = cursor.fetchall()
         assert res == [("xx", -1.0), ("yy", 2.5), ("zz", 6.0)]
 
     # arrow table
@@ -70,7 +74,7 @@ def test_arrow_execution_option() -> None:
 
     with engine.connect().execution_options(duckdb_arrow=True) as con:
         result = con.execute(text("SELECT * FROM tbl ORDER BY label"))
-        table = result.arrow
+        table = cast(Any, result).arrow
         assert isinstance(table, ArrowTable)
         assert table == ArrowTable.from_pydict(
             {"label": ["aa", "bb"], "value": [1.0, 2.0]}


### PR DESCRIPTION
This PR does a targeted reflection refactor in the DuckDB SQLAlchemy dialect.

Single-table primary-key and index reflection had the same control flow in two places: call the corresponding multi-reflection method, look up the `(schema, table)` key, return the SQLAlchemy empty default when the table exists without metadata, and raise `NoSuchTableError` when the table does not exist. Keeping that fallback logic duplicated makes future reflection changes easier to apply to one path but not the other.

The fix extracts that shared path into `Dialect._get_single_reflection_result` and routes `get_pk_constraint` and `get_indexes` through it. The public behavior stays the same, but the table-existence/default fallback now lives in one place.

While checking CI locally, `ty` also surfaced stale test typing issues. I kept those changes narrow: removed obsolete `type: ignore` comments in touched test files, made Python 3.9-compatible type syntax in a test helper, cast dynamic SQLAlchemy/Arrow surfaces where the runtime API is intentionally wider than the static types, and imported the concrete `OperationalError` used by a checkpoint test.

Validation run locally:

- `uv run --extra dev pytest` -> 194 passed, 7 skipped
- `uv run --extra dev ty check duckdb_sqlalchemy` -> exits successfully with one pre-existing conftest warning
- `pre-commit run --all-files` -> passed
- `git diff --check` -> passed
