### PR TITLE
chore: release 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ preserved from the upstream project for historical context.
 
 ## Unreleased
 
+## [1.5.2](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.1.4...v1.5.2) (2026-04-17)
+
 ### Features
 
 - prefer MotherDuck's new `session_name` connection parameter while keeping `session_hint`, `motherduck_session_hint`, and `motherduck_session_name` as deprecated aliases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.1.4"
+version = "1.5.2"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.1.4"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- bump package metadata to 1.5.2
- cut the 1.5.2 changelog entry for DuckDB 1.5.2 support

## Tests
- uv run --extra dev pytest
- uv run --with build python -m build
- pre-commit run --all-files