### PR TITLE
[codex] refactor reflection fallbacks

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Collection,
     Dict,
     Iterable,
@@ -966,6 +967,20 @@ class Dialect(PGDialect_psycopg2):
         sql += where_sql
         return connection.execute(text(sql), params).first() is not None
 
+    def _get_reflection_or_empty_for_existing_table(
+        self,
+        getter: Callable[[], List[Any]],
+        connection: "Connection",
+        table_name: str,
+        schema: Optional[str],
+    ) -> List[Any]:
+        try:
+            return getter()
+        except NoSuchTableError:
+            if self._duckdb_table_exists(connection, table_name, schema):
+                return []
+            raise
+
     def _duckdb_columns(
         self, connection: "Connection", table_name: str, schema: Optional[str]
     ) -> Optional[List[Dict[str, Any]]]:
@@ -1334,18 +1349,19 @@ class Dialect(PGDialect_psycopg2):
         postgresql_ignore_search_path: bool = False,
         **kw: Any,
     ) -> List["ReflectedForeignKeyConstraint"]:
-        try:
-            return super().get_foreign_keys(
+        super_get_foreign_keys = super().get_foreign_keys
+        return self._get_reflection_or_empty_for_existing_table(
+            lambda: super_get_foreign_keys(
                 connection,
                 table_name,
                 schema=schema,
                 postgresql_ignore_search_path=postgresql_ignore_search_path,
                 **kw,
-            )
-        except NoSuchTableError:
-            if self._duckdb_table_exists(connection, table_name, schema):
-                return []
-            raise
+            ),
+            connection,
+            table_name,
+            schema,
+        )
 
     @cache  # type: ignore[call-arg]
     def get_unique_constraints(
@@ -1355,14 +1371,15 @@ class Dialect(PGDialect_psycopg2):
         schema: Optional[str] = None,
         **kw: Any,
     ) -> List["ReflectedUniqueConstraint"]:
-        try:
-            return super().get_unique_constraints(
+        super_get_unique_constraints = super().get_unique_constraints
+        return self._get_reflection_or_empty_for_existing_table(
+            lambda: super_get_unique_constraints(
                 connection, table_name, schema=schema, **kw
-            )
-        except NoSuchTableError:
-            if self._duckdb_table_exists(connection, table_name, schema):
-                return []
-            raise
+            ),
+            connection,
+            table_name,
+            schema,
+        )
 
     @cache  # type: ignore[call-arg]
     def get_check_constraints(
@@ -1372,14 +1389,15 @@ class Dialect(PGDialect_psycopg2):
         schema: Optional[str] = None,
         **kw: Any,
     ) -> List["ReflectedCheckConstraint"]:
-        try:
-            return super().get_check_constraints(
+        super_get_check_constraints = super().get_check_constraints
+        return self._get_reflection_or_empty_for_existing_table(
+            lambda: super_get_check_constraints(
                 connection, table_name, schema=schema, **kw
-            )
-        except NoSuchTableError:
-            if self._duckdb_table_exists(connection, table_name, schema):
-                return []
-            raise
+            ),
+            connection,
+            table_name,
+            schema,
+        )
 
     def get_indexes(
         self,

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -698,6 +698,46 @@ def test_duckdb_reflection_filters_share_schema_database_builder() -> None:
     }
 
 
+def test_reflection_fallback_returns_empty_only_for_existing_tables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dialect = Dialect()
+    connection = object()
+    seen: list[tuple[object, str, Optional[str]]] = []
+
+    def existing_table(conn: object, table_name: str, schema: Optional[str]) -> bool:
+        seen.append((conn, table_name, schema))
+        return True
+
+    def missing_table(conn: object, table_name: str, schema: Optional[str]) -> bool:
+        seen.append((conn, table_name, schema))
+        return False
+
+    def unsupported_reflection() -> list[Any]:
+        raise sa_exc.NoSuchTableError("orders")
+
+    monkeypatch.setattr(dialect, "_duckdb_table_exists", existing_table)
+    assert (
+        dialect._get_reflection_or_empty_for_existing_table(
+            unsupported_reflection,
+            cast(Any, connection),
+            "orders",
+            "main",
+        )
+        == []
+    )
+    assert seen == [(connection, "orders", "main")]
+
+    monkeypatch.setattr(dialect, "_duckdb_table_exists", missing_table)
+    with pytest.raises(sa_exc.NoSuchTableError):
+        dialect._get_reflection_or_empty_for_existing_table(
+            unsupported_reflection,
+            cast(Any, connection),
+            "orders",
+            "main",
+        )
+
+
 def test_parse_duckdb_enum_labels_unquotes_escaped_strings() -> None:
     labels, enum_name = Dialect()._parse_duckdb_enum_labels(
         "ENUM('alpha', 'it''s fine')",


### PR DESCRIPTION
This PR makes a small targeted refactor in DuckDB reflection fallback handling.

DuckDB does not expose every PostgreSQL-compatible reflection surface that SQLAlchemy's PostgreSQL dialect expects. For a real DuckDB table, methods such as foreign key, unique constraint, and check constraint reflection can legitimately have no supported metadata to return, so the dialect maps that PostgreSQL `NoSuchTableError` path to an empty list only after confirming the table exists.

Before this change, each reflection method repeated the same try/except and table-existence check. That made it easier for future changes to drift between reflection methods or accidentally swallow missing-table errors too broadly.

The fix extracts the shared fallback into `_get_reflection_or_empty_for_existing_table`, then routes foreign key, unique constraint, and check constraint reflection through that helper. Missing tables still raise `NoSuchTableError`; only existing DuckDB tables with unsupported metadata return an empty list.

Validation performed locally:

- `uv run --extra dev --extra devtools pytest duckdb_sqlalchemy/tests/test_core_units.py -q`
- `uv run --extra dev --extra devtools pre-commit run --all-files`
- `uv run --extra dev --extra devtools pytest -q`
