### PR TITLE
[codex] refactor bulk row normalization

### DIFF
--- a/duckdb_sqlalchemy/bulk.py
+++ b/duckdb_sqlalchemy/bulk.py
@@ -155,6 +155,27 @@ def _copy_rows_as_csv_chunks(
             _close_and_unlink_tempfile(tmp)
 
 
+def _copy_rows_as_sequences(
+    first: Union[Mapping[str, Any], Sequence[Any]],
+    rows: Iterable[Union[Mapping[str, Any], Sequence[Any]]],
+    columns: Optional[Sequence[str]],
+) -> Tuple[Iterable[Sequence[Any]], Optional[Sequence[str]]]:
+    if isinstance(first, Mapping):
+        if columns is None:
+            columns = [str(col) for col in cast(Mapping[str, Any], first).keys()]
+
+        def row_to_seq(row: Mapping[str, Any]) -> Sequence[Any]:
+            return [row.get(col) for col in columns or []]
+
+        first_row = row_to_seq(cast(Mapping[str, Any], first))
+        remaining_rows = (row_to_seq(cast(Mapping[str, Any], row)) for row in rows)
+        return chain((first_row,), remaining_rows), columns
+
+    first_row = cast(Sequence[Any], first)
+    remaining_rows = (cast(Sequence[Any], row) for row in rows)
+    return chain((first_row,), remaining_rows), columns
+
+
 def copy_from_parquet(
     connection: Any,
     table: TableLike,
@@ -227,20 +248,7 @@ def copy_from_rows(
 
     copy_options = {"header": include_header, **copy_options}
 
-    if isinstance(first, Mapping):
-        if columns is None:
-            columns = [str(col) for col in cast(Mapping[str, Any], first).keys()]
-
-        def row_to_seq(row: Mapping[str, Any]) -> Sequence[Any]:
-            return [row.get(col) for col in columns or []]
-
-        first_row = row_to_seq(cast(Mapping[str, Any], first))
-        remaining_rows = (row_to_seq(cast(Mapping[str, Any], row)) for row in iterator)
-    else:
-        first_row = cast(Sequence[Any], first)
-        remaining_rows = (cast(Sequence[Any], row) for row in iterator)
-
-    chunked_rows = chain((first_row,), remaining_rows)
+    chunked_rows, columns = _copy_rows_as_sequences(first, iterator, columns)
     _copy_rows_as_csv_chunks(
         connection,
         table,

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -872,6 +872,28 @@ def test_copy_from_rows_sequence_uses_explicit_columns_and_chunks() -> None:
     assert rows == [(1, "one"), (2, "two"), (3, "three")]
 
 
+def test_copy_rows_as_sequences_infers_mapping_columns() -> None:
+    rows, columns = duckdb_sqlalchemy.bulk._copy_rows_as_sequences(
+        {"id": 1, "label": "one"},
+        [{"id": 2, "label": "two"}],
+        None,
+    )
+
+    assert columns == ["id", "label"]
+    assert list(rows) == [[1, "one"], [2, "two"]]
+
+
+def test_copy_rows_as_sequences_uses_explicit_mapping_columns() -> None:
+    rows, columns = duckdb_sqlalchemy.bulk._copy_rows_as_sequences(
+        {"id": 1, "label": "one"},
+        [{"id": 2}],
+        ["label", "id"],
+    )
+
+    assert columns == ["label", "id"]
+    assert list(rows) == [["one", 1], [None, 2]]
+
+
 def test_copy_from_rows_closes_rotated_tempfiles(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
This PR tightens the bulk row-copy path by extracting the row-shape normalization in `copy_from_rows` into a focused private helper.

`copy_from_rows` previously handled empty input, mapping-column inference, explicit mapping-column ordering, sequence rows, copy options, and CSV chunk writing in one function. The behavior was correct, but the row normalization logic was embedded in the orchestration path, making the mapping and sequence branches harder to test directly and easier to drift as chunked-copy behavior evolves.

The refactor keeps the public API and generated COPY behavior the same while separating the normalization step from the chunk-writing step. Mapping rows still infer columns from the first row when no explicit columns are provided, explicit mapping columns still control output order, and missing mapping values still flow through as `None`.

What changed:

- Added `_copy_rows_as_sequences` to convert mapping or sequence inputs into CSV-ready row sequences.
- Simplified `copy_from_rows` so it delegates row normalization before calling the existing CSV chunk writer.
- Added focused unit coverage for inferred mapping columns and explicit mapping column ordering.

Validation:

- `uv run --extra dev --extra devtools pytest duckdb_sqlalchemy/tests/test_core_units.py -q`
- `uv run --extra dev --extra devtools pytest -q`
- `uv run --extra dev --extra devtools pre-commit run --all-files`
