### PR TITLE
[codex] fix motherduck startup options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         language: python
         files: ^duckdb_sqlalchemy/(?!tests/).*\.py$
         additional_dependencies:
-          - "ty==0.0.31"
+          - "ty==0.0.32"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: 'v0.15.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ preserved from the upstream project for historical context.
 
 ## Unreleased
 
+### Bug Fixes
+
+- treat MotherDuck transport overrides such as `host`, `region_host`, `port`, `tls`, and `grpc_local_subchannel_pool` as startup URL parameters so SQLAlchemy URLs and `connect_args["config"]` keep working with current MotherDuck routing behavior
+- restore the exported package version to `1.5.2` so the runtime version matches published package metadata
+
+### Tooling
+
+- bump the local `ty` pin to `0.0.32` after validating the current checks against the latest non-breaking release
+
 ## [1.5.2](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.1.4...v1.5.2) (2026-04-17)
 
 ### Features

--- a/docs/motherduck.md
+++ b/docs/motherduck.md
@@ -62,12 +62,13 @@ string for MotherDuck connections.
 Parameters that are treated as part of the database string:
 
 - `user`
+- `host`, `region_host`, `port`, `tls`, `grpc_local_subchannel_pool`
 - `session_name` (read-scaling affinity)
 - `attach_mode` (`workspace` or `single`)
 - `access_mode` (`read_only` for read-scaling tokens)
 - `dbinstance_inactivity_ttl` (preferred; `motherduck_dbinstance_inactivity_ttl`
   remains supported but is deprecated)
-- `saas_mode`
+- `saas_mode` (`pgendpoint` is supported when you need PG endpoint-compatible routing)
 - `cache_buster`
 
 For backward compatibility the dialect also accepts `session_hint`,
@@ -88,7 +89,15 @@ If you pass these in `connect_args["config"]`, the dialect will move them into t
 Other DuckDB settings can be passed as URL query params or via `connect_args["config"]`:
 
 - Any DuckDB `SET`-table config option (for example `memory_limit`, `threads`)
-- MotherDuck startup auth keys such as `motherduck_token` and `motherduck_oauth_token`
+- MotherDuck startup auth keys such as `motherduck_token`, `token`, `motherduck_oauth_token`, and `oauth_token`
+
+Example with a MotherDuck host override / PG endpoint-style routing:
+
+```python
+engine = create_engine(
+    "duckdb:///md:my_db?host=custom.motherduck.com&port=443&tls=true&saas_mode=pgendpoint"
+)
+```
 
 ## Recommended defaults for apps/BI
 

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -70,7 +70,7 @@ else:
         _pg_base, "PGExecutionContext", DefaultExecutionContext
     )
 
-__version__ = "1.5.1.4"
+__version__ = "1.5.2"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/duckdb_sqlalchemy/motherduck.py
+++ b/duckdb_sqlalchemy/motherduck.py
@@ -27,17 +27,30 @@ from ._query import merge_query_mappings
 DBINSTANCE_INACTIVITY_TTL_KEY = "dbinstance_inactivity_ttl"
 MOTHERDUCK_DBINSTANCE_INACTIVITY_TTL_KEY = "motherduck_dbinstance_inactivity_ttl"
 MOTHERDUCK_ATTACH_MODE_KEY = "motherduck_attach_mode"
+HOST_KEY = "host"
+REGION_HOST_KEY = "region_host"
+PORT_KEY = "port"
+TLS_KEY = "tls"
+GRPC_LOCAL_SUBCHANNEL_POOL_KEY = "grpc_local_subchannel_pool"
+SHORT_LIVED_TOKEN_KEY = "slt"
 SESSION_HINT_KEY = "session_hint"
 SESSION_NAME_KEY = "session_name"
 MOTHERDUCK_SESSION_HINT_KEY = "motherduck_session_hint"
 MOTHERDUCK_SESSION_NAME_KEY = "motherduck_session_name"
 MOTHERDUCK_SAAS_MODE_KEY = "motherduck_saas_mode"
+TOKEN_ALIAS_KEY = "token"
 MOTHERDUCK_OAUTH_TOKEN_KEY = "motherduck_oauth_token"
 OAUTH_TOKEN_ALIAS_KEY = "oauth_token"
 CACHE_BUST_ALIAS_KEY = "cachebust"
 
 MOTHERDUCK_PATH_QUERY_KEYS = {
     "user",
+    HOST_KEY,
+    REGION_HOST_KEY,
+    PORT_KEY,
+    TLS_KEY,
+    GRPC_LOCAL_SUBCHANNEL_POOL_KEY,
+    SHORT_LIVED_TOKEN_KEY,
     SESSION_NAME_KEY,
     MOTHERDUCK_SESSION_NAME_KEY,
     SESSION_HINT_KEY,
@@ -54,6 +67,7 @@ MOTHERDUCK_PATH_QUERY_KEYS = {
 }
 
 MOTHERDUCK_CONFIG_KEYS = MOTHERDUCK_PATH_QUERY_KEYS | {
+    TOKEN_ALIAS_KEY,
     "motherduck_token",
     MOTHERDUCK_OAUTH_TOKEN_KEY,
     OAUTH_TOKEN_ALIAS_KEY,

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -67,6 +67,11 @@ def test_create_connect_args_moves_user_query_param() -> None:
         database="md:my_db",
         query={
             "user": "alice",
+            "host": "custom.motherduck.com",
+            "region_host": "us-east-1.aws.motherduck.com",
+            "port": 443,
+            "tls": False,
+            "grpc_local_subchannel_pool": True,
             "session_name": "hint",
             "attach_mode": "single",
             "cache_buster": "123",
@@ -83,12 +88,67 @@ def test_create_connect_args_moves_user_query_param() -> None:
     assert database == "md:my_db"
     assert parse_qs(query) == {
         "user": ["alice"],
+        "host": ["custom.motherduck.com"],
+        "region_host": ["us-east-1.aws.motherduck.com"],
+        "port": ["443"],
+        "tls": ["false"],
+        "grpc_local_subchannel_pool": ["true"],
         "session_name": ["hint"],
         "attach_mode": ["single"],
         "cache_buster": ["123"],
         "dbinstance_inactivity_ttl": ["15m"],
     }
     assert kwargs["url_config"] == {"memory_limit": "1GB"}
+
+
+def test_connect_keeps_token_in_config_and_moves_transport_options(monkeypatch) -> None:
+    captured = {}
+
+    class DummyConn:
+        def execute(self, *args, **kwargs):
+            return self
+
+        def register_filesystem(self, filesystem):
+            return None
+
+        def close(self):
+            return None
+
+    def fake_connect(*cargs, **cparams):
+        captured.update(cparams)
+        return DummyConn()
+
+    monkeypatch.setattr(duckdb_sqlalchemy.duckdb, "connect", fake_connect)
+    monkeypatch.setattr(
+        duckdb_sqlalchemy, "get_core_config", lambda: {"threads", "token"}
+    )
+
+    dialect = Dialect()
+    dialect.connect(
+        database="md:my_db",
+        config={
+            "host": "custom.motherduck.com",
+            "region_host": "us-east-1.aws.motherduck.com",
+            "port": 443,
+            "tls": False,
+            "grpc_local_subchannel_pool": True,
+            "token": "legacy-token",
+            "threads": 4,
+        },
+    )
+
+    database, query = captured["database"].split("?", 1)
+    assert database == "md:my_db"
+    assert parse_qs(query) == {
+        "host": ["custom.motherduck.com"],
+        "region_host": ["us-east-1.aws.motherduck.com"],
+        "port": ["443"],
+        "tls": ["false"],
+        "grpc_local_subchannel_pool": ["true"],
+    }
+    assert captured["config"]["token"] == "legacy-token"
+    assert captured["config"]["threads"] == 4
+    assert captured["config"]["custom_user_agent"].startswith("duckdb-sqlalchemy/1.5.2")
 
 
 def test_create_connect_args_defaults_to_memory_before_path_query() -> None:
@@ -245,9 +305,16 @@ def test_get_core_config_includes_motherduck_keys() -> None:
     core = get_core_config()
 
     expected = {
+        "token",
         "motherduck_token",
         "motherduck_oauth_token",
         "oauth_token",
+        "host",
+        "region_host",
+        "port",
+        "tls",
+        "grpc_local_subchannel_pool",
+        "slt",
         "attach_mode",
         "saas_mode",
         "session_name",
@@ -264,8 +331,10 @@ def test_get_core_config_includes_motherduck_keys() -> None:
 def test_looks_like_motherduck_detection() -> None:
     assert _looks_like_motherduck("md:db", {}) is True
     assert _looks_like_motherduck("motherduck:db", {}) is True
+    assert _looks_like_motherduck("local.db", {"token": "x"}) is True
     assert _looks_like_motherduck("local.db", {"motherduck_token": "x"}) is True
     assert _looks_like_motherduck("local.db", {"motherduck_oauth_token": "x"}) is True
+    assert _looks_like_motherduck("local.db", {"host": "custom.motherduck.com"}) is True
     assert _looks_like_motherduck("local.db", {}) is False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "nox>=2026.2.9,<2027.0.0",
     "pyarrow>=22.0.0; python_version >= '3.10'",
     "pytest>=8.0.0,<10.0.0",
-    "ty==0.0.31",
+    "ty==0.0.32",
     "hypothesis>=6.75.2,<7.0.0",
     "github-action-utils>=1.1.0,<2.0.0",
     "pandas>=1,<2.0; python_version < '3.12'",


### PR DESCRIPTION
This fixes two maintenance issues in the MotherDuck integration and refreshes the local typing tool pin.

The main runtime issue was that several valid MotherDuck startup transport options (`host`, `region_host`, `port`, `tls`, and `grpc_local_subchannel_pool`) were not treated as startup URL parameters in this dialect. In practice that meant SQLAlchemy URLs or `connect_args["config"]` could leave those values in the wrong place, which risks routing the connection with stale defaults or applying options too late. I aligned the option handling with the current MotherDuck behavior in `motherduck/mono`, so those settings are now folded into the database string where the MotherDuck client expects them while legacy auth aliases like `token` continue to work without breaking compatibility.

This also fixes a packaging mismatch where `pyproject.toml` already advertised version `1.5.2` but `duckdb_sqlalchemy.__version__` still exported `1.5.1.4`. That skew can confuse user-agent strings, diagnostics, and any runtime code that reports the installed dialect version. The PR restores the exported runtime version to `1.5.2`, documents the transport override / `saas_mode=pgendpoint` workflow, and bumps the exact `ty` pin to `0.0.32` after validating it locally.

Validation:
- `./.venv/bin/pytest`
- `./.venv/bin/pre-commit run --all-files`
- `./.venv/bin/nox -s ty`
