### PR TITLE
chore: release 1.5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ preserved from the upstream project for historical context.
 
 ## Unreleased
 
+## [1.5.2.1](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.2...v1.5.2.1) (2026-04-25)
+
 ### Bug Fixes
 
 - treat MotherDuck transport overrides such as `host`, `region_host`, `port`, `tls`, and `grpc_local_subchannel_pool` as startup URL parameters so SQLAlchemy URLs and `connect_args["config"]` keep working with current MotherDuck routing behavior

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -75,7 +75,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.2"
+    __version__ = "1.5.2.1"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -149,7 +149,9 @@ def test_connect_keeps_token_in_config_and_moves_transport_options(monkeypatch) 
     }
     assert captured["config"]["token"] == "legacy-token"
     assert captured["config"]["threads"] == 4
-    assert captured["config"]["custom_user_agent"].startswith("duckdb-sqlalchemy/1.5.2")
+    assert captured["config"]["custom_user_agent"].startswith(
+        "duckdb-sqlalchemy/1.5.2.1"
+    )
 
 
 def test_create_connect_args_defaults_to_memory_before_path_query() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.2"
+version = "1.5.2.1"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.2"
+version = "1.5.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- bump package metadata and source fallback version to 1.5.2.1
- move current unreleased notes into the 1.5.2.1 changelog section
- update the user-agent version assertion and lockfile editable package version

## Tests
- pre-commit run --all-files
- uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py -q
- uv build