### PR TITLE
[codex] extract bulk insert builders

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -41,6 +41,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import bindparam
 from sqlalchemy.sql.selectable import Select
 
+from ._bulk_insert import build_bulk_insert_data as _build_bulk_insert_data
 from ._supports import has_comment_support
 from ._validation import validate_extension_name
 from .bulk import copy_from_csv, copy_from_parquet, copy_from_rows
@@ -354,49 +355,6 @@ def _normalize_execution_options(execution_options: Dict[str, Any]) -> Dict[str,
             "duckdb_insertmanyvalues_page_size"
         ]
     return execution_options
-
-
-def _build_bulk_insert_dataframe(
-    rows: Sequence[Any], column_names: Sequence[str]
-) -> Any:
-    try:
-        import pandas as pd  # type: ignore[import-not-found]
-    except Exception:
-        return None
-
-    try:
-        if isinstance(rows[0], dict):
-            return pd.DataFrame.from_records(rows, columns=column_names)
-        return pd.DataFrame(rows, columns=cast(Any, column_names))
-    except Exception:
-        return None
-
-
-def _build_bulk_insert_arrow_table(
-    rows: Sequence[Any], column_names: Sequence[str]
-) -> Any:
-    try:
-        import pyarrow as pa  # type: ignore[import-not-found]
-    except Exception:
-        return None
-
-    try:
-        if isinstance(rows[0], dict):
-            table = pa.Table.from_pylist(rows)
-            if column_names:
-                return table.select(column_names)
-            return table
-        columns = list(zip(*rows)) if rows else [[] for _ in column_names]
-        return pa.Table.from_arrays(columns, names=column_names)
-    except Exception:
-        return None
-
-
-def _build_bulk_insert_data(rows: Sequence[Any], column_names: Sequence[str]) -> Any:
-    data = _build_bulk_insert_dataframe(rows, column_names)
-    if data is not None:
-        return data
-    return _build_bulk_insert_arrow_table(rows, column_names)
 
 
 class DuckDBArrowResult:

--- a/duckdb_sqlalchemy/_bulk_insert.py
+++ b/duckdb_sqlalchemy/_bulk_insert.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any, Sequence, cast
+
+
+def _rows_use_mapping_shape(rows: Sequence[Any]) -> bool:
+    return bool(rows) and isinstance(rows[0], dict)
+
+
+def build_bulk_insert_dataframe(
+    rows: Sequence[Any], column_names: Sequence[str]
+) -> Any:
+    try:
+        import pandas as pd  # type: ignore[import-not-found]
+    except Exception:
+        return None
+
+    try:
+        if _rows_use_mapping_shape(rows):
+            return pd.DataFrame.from_records(rows, columns=column_names)
+        return pd.DataFrame(rows, columns=cast(Any, column_names))
+    except Exception:
+        return None
+
+
+def build_bulk_insert_arrow_table(
+    rows: Sequence[Any], column_names: Sequence[str]
+) -> Any:
+    try:
+        import pyarrow as pa  # type: ignore[import-not-found]
+    except Exception:
+        return None
+
+    try:
+        if _rows_use_mapping_shape(rows):
+            table = pa.Table.from_pylist(rows)
+            if column_names:
+                return table.select(column_names)
+            return table
+        columns = list(zip(*rows)) if rows else [[] for _ in column_names]
+        return pa.Table.from_arrays(columns, names=column_names)
+    except Exception:
+        return None
+
+
+def build_bulk_insert_data(rows: Sequence[Any], column_names: Sequence[str]) -> Any:
+    data = build_bulk_insert_dataframe(rows, column_names)
+    if data is not None:
+        return data
+    return build_bulk_insert_arrow_table(rows, column_names)

--- a/duckdb_sqlalchemy/tests/test_execution_options.py
+++ b/duckdb_sqlalchemy/tests/test_execution_options.py
@@ -53,3 +53,21 @@ def test_build_bulk_insert_data_handles_positional_rows() -> None:
             {"id": 1, "name": "Ada"},
             {"id": 2, "name": "Grace"},
         ]
+
+
+def test_build_bulk_insert_data_handles_mapping_rows() -> None:
+    if (
+        importlib.util.find_spec("pandas") is None
+        and importlib.util.find_spec("pyarrow") is None
+    ):
+        pytest.skip("pandas or pyarrow is required for bulk insert fast path")
+
+    rows = [{"id": 1, "name": "Ada"}, {"id": 2, "name": "Grace"}]
+    data = _build_bulk_insert_data(rows, ["id", "name"])
+
+    assert data is not None
+    if hasattr(data, "to_pydict"):
+        assert data.to_pydict() == {"id": [1, 2], "name": ["Ada", "Grace"]}
+    else:
+        assert list(data.columns) == ["id", "name"]
+        assert data.to_dict(orient="records") == rows


### PR DESCRIPTION
This targeted refactor extracts the bulk insert payload builders out of `duckdb_sqlalchemy/__init__.py` into a dedicated private helper module.

Before this change, the dialect module carried pandas and pyarrow specific dataframe/table construction logic inline beside core connection and execution code. That made the main module harder to navigate and mixed an isolated bulk-insert concern into a very large file. The behavior itself was already correct, but the implementation was harder to maintain because changes to the fast-path register flow required touching a broad module with many unrelated responsibilities.

The root cause was that the initial implementation grew inside the dialect file and never got split back out once the fast path stabilized. As a result, the same bulk-insert shape detection and fallback flow lived as a self-contained block in the middle of the main package entrypoint instead of in a helper that matched its scope.

The fix moves the dataframe and Arrow table builders into `duckdb_sqlalchemy/_bulk_insert.py`, keeps `_build_bulk_insert_data` available from the package root for existing internal callers and tests, and adds focused coverage for mapping-shaped rows so the extracted helper remains behavior-safe for both record-style and positional bulk inserts.

Validation used for this change:

- `uv run pytest -q`
- `uv run ty check --ignore unresolved-import --ignore unused-type-ignore-comment --exclude duckdb_sqlalchemy/tests/** duckdb_sqlalchemy/`
- `uv run pre-commit run --all-files`
