### PR TITLE
[codex] revert pgcompat config aliases

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,10 +49,6 @@ engine = create_engine("duckdb:///analytics.db", connect_args={"read_only": True
   SQL fragments or punctuation in key names are rejected with `ValueError`.
 - Unknown but syntactically valid keys are forwarded to DuckDB and may fail with
   DuckDB's native "unrecognized configuration parameter" error.
-- PostgreSQL compatibility aliases from MotherDuck's PG endpoint are normalized
-  before `SET`: `compatibility_mode`, `nested_types_as`, and
-  `ignore_nanoseconds` become their `pgcompat_*` setting names. Preload the
-  relevant extension before using these settings.
 - MotherDuck path-query options (`attach_mode`, `session_name`, `access_mode`,
   and related keys) are handled specially for `md:` URLs. See
   [motherduck.md](motherduck) and [connection-urls.md](connection-urls).

--- a/docs/motherduck.md
+++ b/docs/motherduck.md
@@ -75,10 +75,6 @@ For backward compatibility the dialect also accepts `session_hint`,
 `motherduck_session_hint`, `motherduck_session_name`,
 `motherduck_attach_mode`, `motherduck_saas_mode`, and `cachebust`, but it
 normalizes them to the canonical keys above and emits a `DeprecationWarning`.
-PG compatibility config aliases released by MotherDuck's PG endpoint
-(`compatibility_mode`, `nested_types_as`, and `ignore_nanoseconds`) are also
-accepted in URL query params or `connect_args["config"]` and normalized to their
-`pgcompat_*` setting names.
 
 Example:
 

--- a/duckdb_sqlalchemy/motherduck.py
+++ b/duckdb_sqlalchemy/motherduck.py
@@ -83,12 +83,6 @@ MOTHERDUCK_CONFIG_KEYS = MOTHERDUCK_PATH_QUERY_KEYS | {
     OAUTH_TOKEN_ALIAS_KEY,
 }
 
-PGCOMPAT_CONFIG_ALIASES = (
-    ("compatibility_mode", "pgcompat_compatibility_mode"),
-    ("nested_types_as", "pgcompat_nested_types_as"),
-    ("ignore_nanoseconds", "pgcompat_ignore_nanoseconds"),
-)
-
 DIALECT_QUERY_KEYS = {"duckdb_sqlalchemy_pool", "pool"}
 CONNECT_ARG_MAPPING_KEYS = ("config", "url_config")
 
@@ -178,22 +172,13 @@ def _normalize_config_aliases(config: Dict[str, Any]) -> Dict[str, Any]:
         alias_key=DBINSTANCE_INACTIVITY_TTL_KEY,
         warn_on_alias=False,
     )
-    normalized = _normalize_alias(
+    return _normalize_alias(
         normalized,
         canonical_key=MOTHERDUCK_OAUTH_TOKEN_KEY,
         alias_key=OAUTH_TOKEN_ALIAS_KEY,
         warn_on_alias=False,
         drop_alias=True,
     )
-    for alias_key, canonical_key in PGCOMPAT_CONFIG_ALIASES:
-        normalized = _normalize_alias(
-            normalized,
-            canonical_key=canonical_key,
-            alias_key=alias_key,
-            warn_on_alias=False,
-            drop_alias=True,
-        )
-    return normalized
 
 
 def _partition_query(

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -426,23 +426,6 @@ def test_normalize_motherduck_config_normalizes_oauth_alias() -> None:
     assert config == {"motherduck_oauth_token": "oauth123"}
 
 
-def test_normalize_motherduck_config_normalizes_pgcompat_aliases() -> None:
-    config = {
-        "compatibility_mode": "looker",
-        "nested_types_as": "json",
-        "ignore_nanoseconds": True,
-        "pgcompat_ignore_nanoseconds": False,
-    }
-
-    _normalize_motherduck_config(config)
-
-    assert config == {
-        "pgcompat_compatibility_mode": "looker",
-        "pgcompat_nested_types_as": "json",
-        "pgcompat_ignore_nanoseconds": False,
-    }
-
-
 def test_has_comment_support_false_on_parser_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -604,7 +604,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "fsspec", version = "2025.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "fsspec", version = "2026.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "fsspec", version = "2026.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "github-action-utils" },
     { name = "hypothesis", version = "6.141.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "hypothesis", version = "6.152.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -664,7 +664,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -732,7 +732,7 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.4.0"
+version = "2026.3.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -747,9 +747,9 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version == '3.10.*'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

This PR rolls back PR #95 (`21ca5987c0de84a4d025d2e27b7e41c5b1bbbfbd`) as requested.

It removes the MotherDuck PG compatibility alias normalization that mapped `compatibility_mode`, `nested_types_as`, and `ignore_nanoseconds` to `pgcompat_*` config settings. It also rolls back the dependency changes from that PR, including `ty` 0.0.33 and the Python >=3.10 `fsspec` lockfile refresh.

The formatting-only cleanup in `duckdb_sqlalchemy/tests/conftest.py` is intentionally retained. Reintroducing the previous CRLF/type-ignore state makes `git diff --check` and the newer type checker fail, and it is unrelated to the requested behavior rollback.

## Validation

- `uv run --extra dev pytest -q` -> 212 passed, 7 skipped.
- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py -q` -> 90 passed.
- `uv run --extra dev ty check duckdb_sqlalchemy/` -> all checks passed.
- `uv run --extra devtools pre-commit run --all-files` -> passed.
- `git diff --check` -> passed.

No release was triggered.
