### PR TITLE
[codex] validate motherduck database names

### DIFF
--- a/docs/motherduck.md
+++ b/docs/motherduck.md
@@ -6,6 +6,7 @@ title: MotherDuck
 # MotherDuck
 
 MotherDuck connections use the `md:` database prefix.
+Database names may not contain commas.
 
 ```python
 from sqlalchemy import create_engine

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -60,6 +60,7 @@ from .motherduck import (
     split_url_query,
     stable_session_hint,
     stable_session_name,
+    validate_motherduck_database_name,
 )
 from .olap import md_user_info, read_csv, read_csv_auto, read_parquet, table_function
 from .url import URL, make_url
@@ -716,6 +717,7 @@ class Dialect(PGDialect_psycopg2):
             cparams["database"] = append_query_to_database(
                 cparams.get("database"), path_query
             )
+        validate_motherduck_database_name(cparams.get("database"))
         _normalize_motherduck_config(config)
 
         ext = {k: config.pop(k) for k in list(config) if k not in core_keys}
@@ -1444,6 +1446,7 @@ class Dialect(PGDialect_psycopg2):
         database = opts.get("database")
         if database in {None, ""}:
             database = ":memory:"
+        validate_motherduck_database_name(database)
         opts["database"] = append_query_to_database(database, path_query)
         return (), opts
 

--- a/duckdb_sqlalchemy/motherduck.py
+++ b/duckdb_sqlalchemy/motherduck.py
@@ -47,6 +47,7 @@ TOKEN_ALIAS_KEY = "token"
 MOTHERDUCK_OAUTH_TOKEN_KEY = "motherduck_oauth_token"
 OAUTH_TOKEN_ALIAS_KEY = "oauth_token"
 CACHE_BUST_ALIAS_KEY = "cachebust"
+MOTHERDUCK_DATABASE_PREFIXES = ("md:", "motherduck:")
 
 MOTHERDUCK_PATH_QUERY_KEYS = {
     "user",
@@ -242,6 +243,17 @@ def append_query_to_database(
     return f"{database}{separator}{query_string}"
 
 
+def validate_motherduck_database_name(database: Optional[str]) -> None:
+    if database is None:
+        return
+    for prefix in MOTHERDUCK_DATABASE_PREFIXES:
+        if database.startswith(prefix):
+            database_name = database.split("?", 1)[0][len(prefix) :]
+            if "," in database_name:
+                raise ValueError("MotherDuck database names cannot contain commas")
+            return
+
+
 def MotherDuckURL(
     *,
     database: str,
@@ -253,6 +265,8 @@ def MotherDuckURL(
     Build a SQLAlchemy URL for MotherDuck, ensuring routing/cache parameters
     live in the database string.
     """
+
+    validate_motherduck_database_name(database)
 
     path_kwargs, config_kwargs = _partition_query(kwargs)
     path_params = _normalize_path_query_mapping(path_query, path_kwargs)

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -1304,6 +1304,13 @@ def test_motherduck_url_coerces_path_and_query_values() -> None:
     assert url.query == {"saas_mode": "false"}
 
 
+def test_motherduck_url_rejects_database_names_with_commas() -> None:
+    with pytest.raises(
+        ValueError, match="MotherDuck database names cannot contain commas"
+    ):
+        md.MotherDuckURL(database="md:analytics,staging")
+
+
 def test_motherduck_url_merges_and_overrides_across_inputs() -> None:
     url = md.MotherDuckURL(
         database="md:db",
@@ -1408,6 +1415,26 @@ def test_split_url_query_partitions_and_ignores_dialect_keys() -> None:
     }
     assert url_config == {"memory_limit": "1GB"}
     assert query["duckdb_sqlalchemy_pool"] == "queue"
+
+
+def test_create_connect_args_rejects_motherduck_database_names_with_commas() -> None:
+    dialect = Dialect()
+    url = URL(database="md:analytics,staging")
+
+    with pytest.raises(
+        ValueError, match="MotherDuck database names cannot contain commas"
+    ):
+        dialect.create_connect_args(url)
+
+
+def test_create_connect_args_allows_local_paths_with_commas() -> None:
+    dialect = Dialect()
+    url = URL(database="/tmp/analytics,staging.db", query={"threads": 4})
+
+    _, kwargs = dialect.create_connect_args(url)
+
+    assert kwargs["database"] == "/tmp/analytics,staging.db"
+    assert kwargs["url_config"] == {"threads": "4"}
 
 
 def test_split_url_query_normalizes_motherduck_setting_aliases() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -664,7 +664,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1512,7 +1512,7 @@ version = "0.2.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "posthog", version = "6.9.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "posthog", version = "7.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "posthog", version = "7.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/36/59ef0a4be1e99dbe3a389fc4b200005f32dffa6dfd6e2ebd1eed6b3ce450/ploomber-core-0.2.27.tar.gz", hash = "sha256:d48bc826e382d095eaa776f67c86786f6473bfc8507a1b1b3671d4b48ddce070", size = 22390, upload-time = "2025-07-21T16:53:47.594Z" }
@@ -1551,7 +1551,7 @@ wheels = [
 
 [[package]]
 name = "posthog"
-version = "7.13.1"
+version = "7.13.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1569,13 +1569,12 @@ resolution-markers = [
 dependencies = [
     { name = "backoff", marker = "python_full_version >= '3.10'" },
     { name = "distro", marker = "python_full_version >= '3.10'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
     { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/09/ecc82b5ba5876164a3807adcc5101466da1e4416600075bdbd2071327457/posthog-7.13.1.tar.gz", hash = "sha256:5e53c57db076807530bbec5634c96673ceae8e8e58b99c983af26f02bb4759aa", size = 194124, upload-time = "2026-04-24T19:08:32.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/54/9c117beaa96519077cae355263712d705e560e8ee7ca4a35373438d1f4d2/posthog-7.13.2.tar.gz", hash = "sha256:a9fc322518bc7f42e24501a0df1072aa60bad6fba759cbe388d167b7e054b052", size = 195555, upload-time = "2026-04-30T09:01:26.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/bf/eafd5e7508b03264b7deb4db6563c4a2830de7114e01ccbf369756b779d1/posthog-7.13.1-py3-none-any.whl", hash = "sha256:fc0f4b4a8878957e1ea8d319b2e4038b66a19625837f59b020cddaaf59fce982", size = 228291, upload-time = "2026-04-24T19:08:30.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/8b/ec789af64ef3d85816a5c4ac8fe1e3c74d6e3bb9675c1325e3b1de4ddb14/posthog-7.13.2-py3-none-any.whl", hash = "sha256:e8ea9a7fa740b453533a76c0f3300b16120a3c27c19ab417cf0e69bb8c210fb6", size = 229762, upload-time = "2026-04-30T09:01:24.144Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue

MotherDuck database names cannot contain commas, but the dialect would previously let comma-containing `md:` and `motherduck:` database names pass through URL construction and SQLAlchemy connect-arg creation. Users would only see the failure later from the underlying connection attempt, after pooling and URL handling had already accepted the value.

## Cause and effect

The dialect already separates MotherDuck database-string parameters from normal DuckDB config parameters, but it did not validate the database-name portion of MotherDuck paths. That made invalid MotherDuck names look valid in `MotherDuckURL`, `create_engine("duckdb:///md:...")`, and direct dialect connection paths. Local DuckDB file paths can legitimately contain commas, so the validation needs to be scoped only to MotherDuck-prefixed databases.

## Fix

This adds a small MotherDuck database-name validator shared by `MotherDuckURL`, `Dialect.create_connect_args`, and direct `Dialect.connect` usage. It rejects commas in the name portion before any query string while leaving non-MotherDuck database paths unchanged. The docs now mention the comma restriction in the MotherDuck setup page.

## Dependency refresh

The lockfile was refreshed within existing constraints. The only resolved package update is `posthog` from `7.13.1` to `7.13.2`, plus resolver metadata updates.

## Validation

- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check --ignore unresolved-import --exclude 'duckdb_sqlalchemy/tests/**' duckdb_sqlalchemy/`
- `uv run --extra devtools pre-commit run --all-files`
- Runtime PoC: invalid `md:analytics,staging` raises `ValueError`; local `/tmp/analytics,staging.db` remains valid.
