### PR TITLE
[codex] deduplicate reflection fallback wrappers

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -947,6 +947,21 @@ class Dialect(PGDialect_psycopg2):
                 return []
             raise
 
+    def _get_super_reflection_or_empty(
+        self,
+        getter: Callable[..., List[Any]],
+        connection: "Connection",
+        table_name: str,
+        schema: Optional[str],
+        **kw: Any,
+    ) -> List[Any]:
+        return self._get_reflection_or_empty_for_existing_table(
+            lambda: getter(connection, table_name, schema=schema, **kw),
+            connection,
+            table_name,
+            schema,
+        )
+
     def _duckdb_columns(
         self, connection: "Connection", table_name: str, schema: Optional[str]
     ) -> Optional[List[Dict[str, Any]]]:
@@ -1333,18 +1348,13 @@ class Dialect(PGDialect_psycopg2):
         postgresql_ignore_search_path: bool = False,
         **kw: Any,
     ) -> List["ReflectedForeignKeyConstraint"]:
-        super_get_foreign_keys = super().get_foreign_keys
-        return self._get_reflection_or_empty_for_existing_table(
-            lambda: super_get_foreign_keys(
-                connection,
-                table_name,
-                schema=schema,
-                postgresql_ignore_search_path=postgresql_ignore_search_path,
-                **kw,
-            ),
+        return self._get_super_reflection_or_empty(
+            super().get_foreign_keys,
             connection,
             table_name,
             schema,
+            postgresql_ignore_search_path=postgresql_ignore_search_path,
+            **kw,
         )
 
     @cache  # type: ignore[call-arg]
@@ -1355,14 +1365,12 @@ class Dialect(PGDialect_psycopg2):
         schema: Optional[str] = None,
         **kw: Any,
     ) -> List["ReflectedUniqueConstraint"]:
-        super_get_unique_constraints = super().get_unique_constraints
-        return self._get_reflection_or_empty_for_existing_table(
-            lambda: super_get_unique_constraints(
-                connection, table_name, schema=schema, **kw
-            ),
+        return self._get_super_reflection_or_empty(
+            super().get_unique_constraints,
             connection,
             table_name,
             schema,
+            **kw,
         )
 
     @cache  # type: ignore[call-arg]
@@ -1373,14 +1381,12 @@ class Dialect(PGDialect_psycopg2):
         schema: Optional[str] = None,
         **kw: Any,
     ) -> List["ReflectedCheckConstraint"]:
-        super_get_check_constraints = super().get_check_constraints
-        return self._get_reflection_or_empty_for_existing_table(
-            lambda: super_get_check_constraints(
-                connection, table_name, schema=schema, **kw
-            ),
+        return self._get_super_reflection_or_empty(
+            super().get_check_constraints,
             connection,
             table_name,
             schema,
+            **kw,
         )
 
     def get_indexes(


### PR DESCRIPTION
## Summary

This is a small targeted refactor in the dialect reflection code. Three single-object reflection methods (`get_foreign_keys`, `get_unique_constraints`, and `get_check_constraints`) all used the same wrapper pattern: call the SQLAlchemy superclass implementation, return an empty list when DuckDB reports an existing table with no reflected metadata, and otherwise preserve `NoSuchTableError` for missing tables.

The duplication made those methods slightly harder to keep in sync. The new `_get_super_reflection_or_empty` helper centralizes that superclass-wrapper path and keeps each public reflection method focused on the metadata it asks SQLAlchemy to reflect.

There should be no behavior change for users. Existing tables still return empty metadata where DuckDB has no corresponding reflection rows, missing tables still raise through the same path, and foreign-key reflection still passes through `postgresql_ignore_search_path`.

## Validation

- `uv run --extra dev pytest -q duckdb_sqlalchemy/tests/test_core_units.py::test_reflection_fallback_returns_empty_only_for_existing_tables`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check duckdb_sqlalchemy/`
- `uv run --extra devtools pre-commit run --all-files`
- `git diff --check`
