### PR TITLE
chore: release 1.5.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,25 @@ preserved from the upstream project for historical context.
 
 ## Unreleased
 
+## [1.5.2.2](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.2.1...v1.5.2.2) (2026-05-11)
+
+### Features
+
+- add `md_user_info()` for querying MotherDuck user and organization metadata through SQLAlchemy table-valued functions
+
 ### Bug Fixes
 
 - prefer the documented `MOTHERDUCK_TOKEN` environment variable over the lowercase fallback when both are set
+- reject MotherDuck database names containing commas before building SQLAlchemy URLs
+- ignore common PostgreSQL session setup statements and transaction isolation declarations emitted by PostgreSQL-oriented clients
 
 ### Tooling
 
+- extract bulk insert builder logic into a focused helper module without changing the public execution option behavior
+- revert unreleased PostgreSQL compatibility-mode aliases before publishing them
 - bump the local `ty` pin to `0.0.34` after validating the current checks against the latest non-breaking release
 - refresh the locked development dependency set to the latest non-breaking releases within existing version caps
+- deduplicate reflection fallback wrapper handling
 
 ## [1.5.2.1](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.2...v1.5.2.1) (2026-04-25)
 

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -77,7 +77,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.2.1"
+    __version__ = "1.5.2.2"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -150,7 +150,7 @@ def test_connect_keeps_token_in_config_and_moves_transport_options(monkeypatch) 
     assert captured["config"]["token"] == "legacy-token"
     assert captured["config"]["threads"] == 4
     assert captured["config"]["custom_user_agent"].startswith(
-        "duckdb-sqlalchemy/1.5.2.1"
+        "duckdb-sqlalchemy/1.5.2.2"
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.2.1"
+version = "1.5.2.2"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.2.1"
+version = "1.5.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- bump package metadata, source-tree fallback version, lockfile, and version assertion to 1.5.2.2
- promote the post-1.5.2.1 changelog entries into the 1.5.2.2 release section

## Verification
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check duckdb_sqlalchemy/`
- `uv run --with build python -m build`
- `uv run --extra devtools pre-commit run --all-files`
- `git diff --check`