### PR TITLE
[codex] refactor olap metadata helpers

### DIFF
--- a/duckdb_sqlalchemy/olap.py
+++ b/duckdb_sqlalchemy/olap.py
@@ -82,25 +82,42 @@ def read_csv_auto(
     return table_function("read_csv_auto", path, columns=columns, **kwargs)
 
 
-def md_user_info(*, columns: Optional[Iterable[str]] = None, **kwargs: Any) -> Any:
+def _motherduck_metadata_function(
+    name: str,
+    default_columns: Iterable[str],
+    *,
+    columns: Optional[Iterable[str]] = None,
+    **kwargs: Any,
+) -> Any:
     return table_function(
+        name,
+        columns=default_columns if columns is None else columns,
+        **kwargs,
+    )
+
+
+def md_user_info(*, columns: Optional[Iterable[str]] = None, **kwargs: Any) -> Any:
+    return _motherduck_metadata_function(
         "md_user_info",
-        columns=MOTHERDUCK_USER_INFO_COLUMNS if columns is None else columns,
+        MOTHERDUCK_USER_INFO_COLUMNS,
+        columns=columns,
         **kwargs,
     )
 
 
 def md_list_dives(*, columns: Optional[Iterable[str]] = None, **kwargs: Any) -> Any:
-    return table_function(
+    return _motherduck_metadata_function(
         "md_list_dives",
-        columns=MOTHERDUCK_LIST_DIVES_COLUMNS if columns is None else columns,
+        MOTHERDUCK_LIST_DIVES_COLUMNS,
+        columns=columns,
         **kwargs,
     )
 
 
 def md_access_tokens(*, columns: Optional[Iterable[str]] = None, **kwargs: Any) -> Any:
-    return table_function(
+    return _motherduck_metadata_function(
         "md_access_tokens",
-        columns=MOTHERDUCK_ACCESS_TOKENS_COLUMNS if columns is None else columns,
+        MOTHERDUCK_ACCESS_TOKENS_COLUMNS,
+        columns=columns,
         **kwargs,
     )

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -604,6 +604,14 @@ def test_md_access_tokens_uses_released_motherduck_columns() -> None:
     ]
 
 
+def test_motherduck_metadata_helpers_allow_custom_columns() -> None:
+    assert list(olap.md_user_info(columns=["username"]).c.keys()) == ["username"]
+    assert list(olap.md_list_dives(columns=["title"]).c.keys()) == ["title"]
+    assert list(olap.md_access_tokens(columns=["token_name"]).c.keys()) == [
+        "token_name"
+    ]
+
+
 def test_cursorwrapper_execute_basic_paths() -> None:
     class DummyConn:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary

This PR refactors the MotherDuck OLAP metadata helper wrappers so their shared default-column behavior lives in one private helper instead of being repeated across each public function.

The behavior users see is unchanged: `md_user_info()`, `md_list_dives()`, and `md_access_tokens()` still expose the released MotherDuck column sets by default, while explicit `columns=` overrides continue to pass through to `table_function`.

## Root Cause

The three helpers all had the same small conditional wrapper around `table_function`: choose the released default column tuple when `columns` is omitted, otherwise use the caller-provided columns. That duplication made future metadata helper additions easy to drift.

## Fix

- Added `_motherduck_metadata_function()` to centralize the default-column fallback.
- Updated the three MotherDuck metadata helpers to call it.
- Added a unit test covering custom column overrides for each helper.

## Validation

- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check duckdb_sqlalchemy/`
- `uv run --extra devtools pre-commit run --all-files`
- `git diff --check`
