### PR TITLE
[codex] extract statement classification helpers

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -42,6 +42,11 @@ from sqlalchemy.sql import bindparam
 from sqlalchemy.sql.selectable import Select
 
 from ._bulk_insert import build_bulk_insert_data as _build_bulk_insert_data
+from ._statements import (
+    DISCONNECT_ERROR_PATTERNS,
+    _is_idempotent_statement,
+    _is_transient_error,
+)
 from ._supports import has_comment_support
 from ._validation import validate_extension_name
 from .bulk import copy_from_csv, copy_from_parquet, copy_from_rows
@@ -535,81 +540,6 @@ def _looks_like_motherduck(database: Optional[str], config: Dict[str, Any]) -> b
     ):
         return True
     return any(k in config for k in MOTHERDUCK_CONFIG_KEYS)
-
-
-DISCONNECT_ERROR_PATTERNS = (
-    "connection closed",
-    "connection reset",
-    "connection refused",
-    "broken pipe",
-    "socket",
-    "network is unreachable",
-    "timed out",
-    "timeout",
-    "could not connect",
-    "failed to connect",
-)
-
-TRANSIENT_ERROR_PATTERNS = (
-    "temporarily unavailable",
-    "service unavailable",
-    "http error: 429",
-    "http error: 503",
-    "http error: 504",
-    "rate limit",
-)
-
-IDEMPOTENT_STATEMENT_PREFIXES = (
-    "select",
-    "show",
-    "describe",
-    "pragma",
-    "explain",
-    "values",
-)
-MUTATING_STATEMENT_PATTERN = re.compile(
-    r"\b("
-    r"insert|update|delete|merge|copy|create|alter|drop|grant|revoke|truncate|"
-    r"call|attach|detach"
-    r")\b"
-)
-
-
-def _strip_leading_sql_comments(statement: str) -> str:
-    sql = statement.lstrip()
-    while sql:
-        if sql.startswith("--"):
-            newline_index = sql.find("\n")
-            if newline_index == -1:
-                return ""
-            sql = sql[newline_index + 1 :].lstrip()
-            continue
-        if sql.startswith("/*"):
-            comment_end = sql.find("*/", 2)
-            if comment_end == -1:
-                return ""
-            sql = sql[comment_end + 2 :].lstrip()
-            continue
-        break
-    return sql
-
-
-def _is_idempotent_statement(statement: str) -> bool:
-    normalized = _strip_leading_sql_comments(statement).lower()
-    if not normalized:
-        return False
-    if normalized.startswith(IDEMPOTENT_STATEMENT_PREFIXES):
-        return True
-    if not normalized.startswith("with"):
-        return False
-    return MUTATING_STATEMENT_PATTERN.search(normalized) is None
-
-
-def _is_transient_error(error: BaseException) -> bool:
-    message = str(error).lower()
-    if any(pattern in message for pattern in DISCONNECT_ERROR_PATTERNS):
-        return False
-    return any(pattern in message for pattern in TRANSIENT_ERROR_PATTERNS)
 
 
 def _pool_override_from_url(url: SAURL) -> Optional[str]:

--- a/duckdb_sqlalchemy/_statements.py
+++ b/duckdb_sqlalchemy/_statements.py
@@ -1,0 +1,75 @@
+import re
+
+DISCONNECT_ERROR_PATTERNS = (
+    "connection closed",
+    "connection reset",
+    "connection refused",
+    "broken pipe",
+    "socket",
+    "network is unreachable",
+    "timed out",
+    "timeout",
+    "could not connect",
+    "failed to connect",
+)
+
+TRANSIENT_ERROR_PATTERNS = (
+    "temporarily unavailable",
+    "service unavailable",
+    "http error: 429",
+    "http error: 503",
+    "http error: 504",
+    "rate limit",
+)
+
+IDEMPOTENT_STATEMENT_PREFIXES = (
+    "select",
+    "show",
+    "describe",
+    "pragma",
+    "explain",
+    "values",
+)
+MUTATING_STATEMENT_PATTERN = re.compile(
+    r"\b("
+    r"insert|update|delete|merge|copy|create|alter|drop|grant|revoke|truncate|"
+    r"call|attach|detach"
+    r")\b"
+)
+
+
+def _strip_leading_sql_comments(statement: str) -> str:
+    sql = statement.lstrip()
+    while sql:
+        if sql.startswith("--"):
+            newline_index = sql.find("\n")
+            if newline_index == -1:
+                return ""
+            sql = sql[newline_index + 1 :].lstrip()
+            continue
+        if sql.startswith("/*"):
+            comment_end = sql.find("*/", 2)
+            if comment_end == -1:
+                return ""
+            sql = sql[comment_end + 2 :].lstrip()
+            continue
+        break
+    return sql
+
+
+def _is_idempotent_statement(statement: str) -> bool:
+    normalized = _strip_leading_sql_comments(statement).lower()
+    if not normalized:
+        return False
+    if normalized.startswith(IDEMPOTENT_STATEMENT_PREFIXES):
+        return True
+    if not normalized.startswith("with"):
+        return False
+    return MUTATING_STATEMENT_PATTERN.search(normalized) is None
+
+
+def _is_transient_error(error: BaseException) -> bool:
+    message = str(error).lower()
+    if any(pattern in message for pattern in DISCONNECT_ERROR_PATTERNS):
+        return False
+    return any(pattern in message for pattern in TRANSIENT_ERROR_PATTERNS)


### PR DESCRIPTION
## Summary

This PR extracts the DuckDB statement classification helpers out of the large dialect module and into `duckdb_sqlalchemy/_statements.py`.

The issue was not a runtime bug; it was a small maintainability problem. Retry eligibility, transient-error detection, disconnect pattern checks, and SQL comment stripping were embedded directly in `duckdb_sqlalchemy/__init__.py`, even though they are pure statement/error classification logic with focused tests. That made the large dialect file harder to scan and made the retry behavior less isolated than it needed to be.

The change moves that logic into a private helper module and imports only the pieces the dialect still needs. The dialect behavior is unchanged: disconnect checks still use the same pattern list, retry execution still calls the same idempotency and transient-error predicates, and the existing private helper names used by tests remain available through the package module.

## Validation

- `uv run --extra devtools pre-commit run --all-files`
- `uv run --extra dev pytest`
- `uv run --extra dev ty check --ignore unresolved-import --exclude 'duckdb_sqlalchemy/tests/**' duckdb_sqlalchemy/`
- `uv run --with ruff ruff check duckdb_sqlalchemy/__init__.py duckdb_sqlalchemy/_statements.py`
