### PR TITLE
[codex] centralize bulk insert row shape

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -42,6 +42,9 @@ from sqlalchemy.sql import bindparam
 from sqlalchemy.sql.selectable import Select
 
 from ._bulk_insert import build_bulk_insert_data as _build_bulk_insert_data
+from ._bulk_insert import (
+    infer_bulk_insert_column_keys as _infer_bulk_insert_column_keys,
+)
 from ._statements import (
     DISCONNECT_ERROR_PATTERNS,
     _is_idempotent_statement,
@@ -1488,8 +1491,8 @@ class Dialect(PGDialect_psycopg2):
         column_keys = getattr(compiled, "column_keys", None)
         if not column_keys:
             column_keys = getattr(compiled, "positiontup", None)
-        if not column_keys and isinstance(parameters[0], dict):
-            column_keys = list(parameters[0].keys())
+        if not column_keys:
+            column_keys = _infer_bulk_insert_column_keys(parameters)
         if not column_keys:
             return False
 

--- a/duckdb_sqlalchemy/_bulk_insert.py
+++ b/duckdb_sqlalchemy/_bulk_insert.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
-from typing import Any, Sequence, cast
+from collections.abc import Mapping
+from typing import Any, Optional, Sequence, cast
 
 
 def _rows_use_mapping_shape(rows: Sequence[Any]) -> bool:
-    return bool(rows) and isinstance(rows[0], dict)
+    return bool(rows) and isinstance(rows[0], Mapping)
+
+
+def infer_bulk_insert_column_keys(rows: Sequence[Any]) -> Optional[list[str]]:
+    if not _rows_use_mapping_shape(rows):
+        return None
+    return [str(key) for key in cast(Mapping[str, Any], rows[0]).keys()]
 
 
 def build_bulk_insert_dataframe(

--- a/duckdb_sqlalchemy/tests/test_execution_options.py
+++ b/duckdb_sqlalchemy/tests/test_execution_options.py
@@ -1,9 +1,11 @@
 import importlib.util
+from collections import UserDict
 
 import pytest
 from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, select
 
 from duckdb_sqlalchemy import _build_bulk_insert_data
+from duckdb_sqlalchemy._bulk_insert import infer_bulk_insert_column_keys
 
 
 def test_bulk_insert_register_path() -> None:
@@ -71,3 +73,10 @@ def test_build_bulk_insert_data_handles_mapping_rows() -> None:
     else:
         assert list(data.columns) == ["id", "name"]
         assert data.to_dict(orient="records") == rows
+
+
+def test_infer_bulk_insert_column_keys_handles_mapping_rows() -> None:
+    rows = [UserDict({"id": 1, "name": "Ada"})]
+
+    assert infer_bulk_insert_column_keys(rows) == ["id", "name"]
+    assert infer_bulk_insert_column_keys([(1, "Ada")]) is None


### PR DESCRIPTION
## Summary

This PR makes the bulk insert fast path use a single helper for mapping-row column inference.

The dialect previously inferred fallback column keys with a local `isinstance(..., dict)` check, while `_bulk_insert.py` had its own row-shape check for building pandas or Arrow data. That duplicated the same decision in two places and meant non-`dict` mapping rows were not handled consistently by the fallback inference path.

The change moves column-key inference into `_bulk_insert.py`, generalizes mapping detection to `collections.abc.Mapping`, and has the dialect call that helper when SQLAlchemy does not provide compiled column keys. Existing positional rows still return `None` from the helper and continue through the old path.

## Validation

- `uv run --extra dev pytest -q duckdb_sqlalchemy/tests/test_execution_options.py`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check duckdb_sqlalchemy/`
- `uv run --extra devtools pre-commit run --all-files`
- `git diff --check`
