### PR TITLE
release 1.5.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         language: python
         files: ^duckdb_sqlalchemy/(?!tests/).*\.py$
         additional_dependencies:
-          - "ty==0.0.35"
+          - "ty==0.0.37"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: 'v0.15.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ preserved from the upstream project for historical context.
 
 ## Unreleased
 
+## [1.5.3](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.2.2...v1.5.3) (2026-06-02)
+
 ### Features
 
 - add `quack_query()` for stateless DuckDB Quack remote queries on DuckDB 1.5.3+

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -112,7 +112,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.2.2"
+    __version__ = "1.5.3"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -149,9 +149,7 @@ def test_connect_keeps_token_in_config_and_moves_transport_options(monkeypatch) 
     }
     assert captured["config"]["token"] == "legacy-token"
     assert captured["config"]["threads"] == 4
-    assert captured["config"]["custom_user_agent"].startswith(
-        "duckdb-sqlalchemy/1.5.2.2"
-    )
+    assert captured["config"]["custom_user_agent"].startswith("duckdb-sqlalchemy/1.5.3")
 
 
 def test_create_connect_args_defaults_to_memory_before_path_query() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.2.2"
+version = "1.5.3"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.2.2"
+version = "1.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- release duckdb-sqlalchemy 1.5.3 for the DuckDB 1.5.3 support line
- move unreleased changelog entries into the 1.5.3 section
- align the pre-commit ty pin with the locked dev dependency

## Verification
- uv run --extra dev pytest --remote-data -rs
- uv run --extra dev nox -s ty
- uv run --extra dev nox -s "tests-3.10(sqlalchemy='2.0.45', duckdb='1.5.3')" "tests-3.10(sqlalchemy='2.0.49', duckdb='1.5.3')" "tests-3.11(sqlalchemy='2.0.45', duckdb='1.5.3')" "tests-3.11(sqlalchemy='2.0.49', duckdb='1.5.3')" "tests-3.12(sqlalchemy='2.0.45', duckdb='1.5.3')" "tests-3.12(sqlalchemy='2.0.49', duckdb='1.5.3')" "tests-3.13(sqlalchemy='2.0.45', duckdb='1.5.3')" "tests-3.13(sqlalchemy='2.0.49', duckdb='1.5.3')" "tests-3.14(sqlalchemy='2.0.45', duckdb='1.5.3')" "tests-3.14(sqlalchemy='2.0.49', duckdb='1.5.3')"
- uv run --with build python -m build
- uv run --with twine twine check dist/*
- uv run --extra dev --extra devtools pre-commit run --all-files
- live MotherDuck smoke: duckdb:///md: with duckdb 1.5.3 returned version() = v1.5.3