### PR TITLE
align release ty pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         language: python
         files: ^duckdb_sqlalchemy/(?!tests/).*\.py$
         additional_dependencies:
-          - "ty==0.0.37"
+          - "ty==0.0.38"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: 'v0.15.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ preserved from the upstream project for historical context.
 - extend the DuckDB compatibility test matrix to include DuckDB 1.5.3
 - update the SQLAlchemy compatibility matrix to include SQLAlchemy 2.0.50
 - refresh the locked development dependency set to the latest non-breaking releases within existing version caps
-- bump the local `ty` pin to `0.0.37` after validating the current checks against the latest non-breaking release
+- bump the local `ty` pin to `0.0.38` after validating the current checks against the latest non-breaking release
 
 ## [1.5.2.2](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.2.1...v1.5.2.2) (2026-05-11)
 


### PR DESCRIPTION
## Summary
- align the pre-commit ty hook with the already-merged 0.0.38 dev dependency
- correct the 1.5.3 changelog tooling entry before release

## Verification
- uv run --extra dev --extra devtools pre-commit run --all-files
- uv run --extra dev nox -s ty