### PR TITLE
[codex] centralize MotherDuck path query handling

### DIFF
--- a/.github/workflows/pythonapp.yaml
+++ b/.github/workflows/pythonapp.yaml
@@ -66,4 +66,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: PYTHON
           fail_ci_if_error: true
+          use_pypi: true
           verbose: true

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -60,6 +60,7 @@ from .motherduck import (
     DIALECT_QUERY_KEYS,
     MOTHERDUCK_CONFIG_KEYS,
     MotherDuckURL,
+    _database_with_path_query,
     _normalize_config_aliases,
     append_query_to_database,
     create_engine_from_paths,
@@ -157,12 +158,14 @@ __all__ = [
     "insert",  # reexport of sqlalchemy.dialects.postgresql.insert
     "MotherDuckURL",
     "URL",
+    "append_query_to_database",
     "create_engine_from_paths",
     "create_motherduck_engine",
     "make_url",
     "stable_session_hint",
     "stable_session_name",
     "table_function",
+    "validate_motherduck_database_name",
     "read_parquet",
     "read_csv",
     "read_csv_auto",
@@ -763,11 +766,9 @@ class Dialect(PGDialect_psycopg2):
             cparams["database"] = ":memory:"
         _apply_motherduck_defaults(config, cparams.get("database"))
         path_query = extract_path_query_from_config(config)
-        if path_query:
-            cparams["database"] = append_query_to_database(
-                cparams.get("database"), path_query
-            )
-        validate_motherduck_database_name(cparams.get("database"))
+        cparams["database"] = _database_with_path_query(
+            cparams.get("database"), path_query
+        )
         _normalize_motherduck_config(config)
         application_name = _pop_application_name(config)
 
@@ -1505,8 +1506,7 @@ class Dialect(PGDialect_psycopg2):
         database = opts.get("database")
         if database in {None, ""}:
             database = ":memory:"
-        validate_motherduck_database_name(database)
-        opts["database"] = append_query_to_database(database, path_query)
+        opts["database"] = _database_with_path_query(database, path_query)
         return (), opts
 
     @classmethod

--- a/duckdb_sqlalchemy/motherduck.py
+++ b/duckdb_sqlalchemy/motherduck.py
@@ -228,6 +228,13 @@ def append_query_to_database(
     return f"{database}{separator}{query_string}"
 
 
+def _database_with_path_query(
+    database: Optional[str], *mappings: Optional[Mapping[str, Any]]
+) -> Optional[str]:
+    validate_motherduck_database_name(database)
+    return append_query_to_database(database, _normalize_path_query_mapping(*mappings))
+
+
 def validate_motherduck_database_name(database: Optional[str]) -> None:
     if database is None:
         return
@@ -251,13 +258,10 @@ def MotherDuckURL(
     live in the database string.
     """
 
-    validate_motherduck_database_name(database)
-
     path_kwargs, config_kwargs = _partition_query(kwargs)
-    path_params = _normalize_path_query_mapping(path_query, path_kwargs)
     config_params = merge_query_mappings(query, config_kwargs)
 
-    database_with_query = append_query_to_database(database, path_params)
+    database_with_query = _database_with_path_query(database, path_query, path_kwargs)
     return SAURL.create("duckdb", database=database_with_query, query=config_params)
 
 

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -1633,6 +1633,28 @@ def test_motherduck_helpers() -> None:
     assert normalized.database == "md:db"
 
 
+def test_database_with_path_query_normalizes_and_appends() -> None:
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        database = md._database_with_path_query(
+            "md:db?user=alice",
+            {"motherduck_host": "api.staging.motherduck.com"},
+            {"tls": False},
+        )
+
+    assert database is not None
+    database_name, query = database.split("?", 1)
+    assert database_name == "md:db"
+    assert parse_qs(query) == {
+        "user": ["alice"],
+        "host": ["api.staging.motherduck.com"],
+        "tls": ["false"],
+    }
+    assert [str(w.message) for w in recorded] == [
+        "`motherduck_host` is deprecated; use `host` instead.",
+    ]
+
+
 def test_motherduck_url_coerces_path_and_query_values() -> None:
     url = md.MotherDuckURL(
         database="md:db",


### PR DESCRIPTION
## Summary

This PR centralizes the small piece of MotherDuck database path-query handling that was repeated across the URL builder, direct dialect connection setup, and SQLAlchemy URL parsing.

Previously each path split normalized MotherDuck routing options, appended them to the database string, and validated the MotherDuck database name at the call site. That made the same control flow show up in multiple places and left the validation/append ordering easy to drift.

The change adds one internal `_database_with_path_query` helper in `motherduck.py` and routes `MotherDuckURL`, `Dialect.connect`, and `Dialect.create_connect_args` through it. Public behavior is intended to stay the same: MotherDuck path parameters still move into the database URL, config parameters stay in `url_config`/`config`, deprecated aliases still warn and normalize, and MotherDuck database names with commas are still rejected.

I also made the two existing top-level MotherDuck helper imports explicit in `__all__`, because they were already imported by `duckdb_sqlalchemy.__init__` and Ruff now treats the no-longer-used import path as a re-export only when it is listed there.

CI was also failing after tests passed because the Codecov action could not verify the latest downloaded CLI signature. The workflow now sets `use_pypi: true` for `codecov/codecov-action`, which keeps coverage upload on the action-supported PyPI CLI path instead of the failing latest-binary download.

## Validation

- `uv run --extra dev pytest -q duckdb_sqlalchemy/tests/test_core_units.py -k 'motherduck or create_connect_args'`
- `uv run --extra dev ty check duckdb_sqlalchemy/`
- `uv run --extra dev pytest -q`
- `uv run --extra devtools pre-commit run --all-files`
- commit hook pre-commit run during both commits
