### PR TITLE
[codex] extract arrow result wrapper

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -41,6 +41,7 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import bindparam
 from sqlalchemy.sql.selectable import Select
 
+from ._arrow import DuckDBArrowResult
 from ._bulk_insert import build_bulk_insert_data as _build_bulk_insert_data
 from ._bulk_insert import (
     infer_bulk_insert_column_keys as _infer_bulk_insert_column_keys,
@@ -475,44 +476,6 @@ def _normalize_execution_options(execution_options: Dict[str, Any]) -> Dict[str,
             "duckdb_insertmanyvalues_page_size"
         ]
     return execution_options
-
-
-class DuckDBArrowResult:
-    def __init__(self, result: Any) -> None:
-        self._result = result
-        self._arrow = None
-
-    def _fetch_arrow(self) -> Any:
-        if self._arrow is not None:
-            return self._arrow
-        cursor = getattr(self._result, "cursor", None)
-        if cursor is None:
-            cursor = getattr(self._result, "_cursor", None)
-        if cursor is None:
-            raise NotImplementedError("Arrow results are not available on this cursor")
-        fetch_arrow_table = getattr(cursor, "to_arrow_table", None)
-        if fetch_arrow_table is None:
-            fetch_arrow_table = getattr(cursor, "fetch_arrow_table", None)
-        if fetch_arrow_table is None:
-            raise NotImplementedError("Arrow results are not available on this cursor")
-        self._arrow = fetch_arrow_table()
-        return self._arrow
-
-    @property
-    def arrow(self) -> Any:
-        return self._fetch_arrow()
-
-    def all(self) -> Any:
-        return self._fetch_arrow()
-
-    def fetchall(self) -> Any:
-        return self._fetch_arrow()
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._result, name)
-
-    def __iter__(self) -> Any:
-        return iter(self._result)
 
 
 class DuckDBExecutionContext(_PGExecutionContext):

--- a/duckdb_sqlalchemy/_arrow.py
+++ b/duckdb_sqlalchemy/_arrow.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+
+class DuckDBArrowResult:
+    def __init__(self, result: Any) -> None:
+        self._result = result
+        self._arrow = None
+
+    def _fetch_arrow(self) -> Any:
+        if self._arrow is not None:
+            return self._arrow
+        cursor = getattr(self._result, "cursor", None)
+        if cursor is None:
+            cursor = getattr(self._result, "_cursor", None)
+        if cursor is None:
+            raise NotImplementedError("Arrow results are not available on this cursor")
+        fetch_arrow_table = getattr(cursor, "to_arrow_table", None)
+        if fetch_arrow_table is None:
+            fetch_arrow_table = getattr(cursor, "fetch_arrow_table", None)
+        if fetch_arrow_table is None:
+            raise NotImplementedError("Arrow results are not available on this cursor")
+        self._arrow = fetch_arrow_table()
+        return self._arrow
+
+    @property
+    def arrow(self) -> Any:
+        return self._fetch_arrow()
+
+    def all(self) -> Any:
+        return self._fetch_arrow()
+
+    def fetchall(self) -> Any:
+        return self._fetch_arrow()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._result, name)
+
+    def __iter__(self) -> Any:
+        return iter(self._result)


### PR DESCRIPTION
## Summary

This PR performs a small targeted refactor of the Arrow execution-option result wrapper. The dialect's main `__init__.py` had an isolated `DuckDBArrowResult` class embedded next to execution-context setup, even though the wrapper is self-contained and only needs the wrapped SQLAlchemy result object.

The effect for users is intentionally unchanged: queries executed with `duckdb_arrow=True` still return a result object exposing `.arrow`, `.all()`, and `.fetchall()` backed by DuckDB's Arrow table methods. The refactor just moves that wrapper into a focused private module so the large dialect module carries less unrelated implementation detail.

## Root Cause

`DuckDBArrowResult` was a compact but independent helper inside the already-large dialect module. Keeping it there made the execution-context section harder to scan and coupled Arrow result wrapping to the main dialect file more than necessary.

## Fix

- Added `duckdb_sqlalchemy/_arrow.py` containing `DuckDBArrowResult`.
- Imported the wrapper in `duckdb_sqlalchemy/__init__.py` where `DuckDBExecutionContext._setup_result_proxy()` uses it.
- Left behavior and public APIs unchanged.

## Validation

- `uv run --extra dev pytest -q duckdb_sqlalchemy/tests/test_pyarrow.py duckdb_sqlalchemy/tests/test_core_units.py -k 'arrow or execution_options'`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check duckdb_sqlalchemy`
- `uv run --extra dev --extra devtools pre-commit run --all-files`
