### PR TITLE
[codex] extract connect config prep

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -616,6 +616,25 @@ def _pop_application_name(config: Dict[str, Any]) -> Optional[str]:
     return str(application_name)
 
 
+def _prepare_connection_params(
+    cparams: Dict[str, Any], core_keys: Collection[str]
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    config = dict(cparams.get("config", {}))
+    cparams["config"] = config
+    config.update(cparams.pop("url_config", {}))
+    for key in DIALECT_QUERY_KEYS:
+        config.pop(key, None)
+    if cparams.get("database") in {None, ""}:
+        cparams["database"] = ":memory:"
+    _apply_motherduck_defaults(config, cparams.get("database"))
+    path_query = extract_path_query_from_config(config)
+    cparams["database"] = _database_with_path_query(cparams.get("database"), path_query)
+    _normalize_motherduck_config(config)
+    application_name = _pop_application_name(config)
+    ext = {k: config.pop(k) for k in list(config) if k not in core_keys}
+    return ext, application_name
+
+
 class DuckDBIdentifierPreparer(PGIdentifierPreparer):
     def __init__(self, dialect: "Dialect", **kwargs: Any) -> None:
         super().__init__(dialect, **kwargs)
@@ -720,22 +739,8 @@ class Dialect(PGDialect_psycopg2):
     def connect(self, *cargs: Any, **cparams: Any) -> Any:
         core_keys = get_core_config()
         preload_extensions = cparams.pop("preload_extensions", [])
-        config = dict(cparams.get("config", {}))
-        cparams["config"] = config
-        config.update(cparams.pop("url_config", {}))
-        for key in DIALECT_QUERY_KEYS:
-            config.pop(key, None)
-        if cparams.get("database") in {None, ""}:
-            cparams["database"] = ":memory:"
-        _apply_motherduck_defaults(config, cparams.get("database"))
-        path_query = extract_path_query_from_config(config)
-        cparams["database"] = _database_with_path_query(
-            cparams.get("database"), path_query
-        )
-        _normalize_motherduck_config(config)
-        application_name = _pop_application_name(config)
-
-        ext = {k: config.pop(k) for k in list(config) if k not in core_keys}
+        ext, application_name = _prepare_connection_params(cparams, core_keys)
+        config = cparams["config"]
         if supports_user_agent:
             user_agent = (
                 f"duckdb-sqlalchemy/{__version__}(sqlalchemy/{sqlalchemy_version})"

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -25,6 +25,7 @@ from duckdb_sqlalchemy import (
     _normalize_motherduck_config,
     _parse_register_params,
     _pool_override_from_url,
+    _prepare_connection_params,
     _supports,
     create_engine_from_paths,
     olap,
@@ -150,6 +151,36 @@ def test_connect_keeps_token_in_config_and_moves_transport_options(monkeypatch) 
     assert captured["config"]["token"] == "legacy-token"
     assert captured["config"]["threads"] == 4
     assert captured["config"]["custom_user_agent"].startswith("duckdb-sqlalchemy/1.5.3")
+
+
+def test_prepare_connection_params_normalizes_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MOTHERDUCK_TOKEN", raising=False)
+    monkeypatch.delenv("motherduck_token", raising=False)
+    cparams = {
+        "database": "md:my_db",
+        "config": {
+            "host": "custom.motherduck.com",
+            "threads": 4,
+            "application_name": "analytics-app",
+            "custom_setting": "value",
+        },
+        "url_config": {
+            "memory_limit": "1GB",
+            "duckdb_sqlalchemy_pool": "queue",
+        },
+    }
+
+    ext, application_name = _prepare_connection_params(cparams, {"threads"})
+
+    database, query = cparams["database"].split("?", 1)
+    assert database == "md:my_db"
+    assert parse_qs(query) == {"host": ["custom.motherduck.com"]}
+    assert cparams["config"] == {"threads": 4}
+    assert ext == {"custom_setting": "value", "memory_limit": "1GB"}
+    assert application_name == "analytics-app"
+    assert "url_config" not in cparams
 
 
 def test_connect_moves_application_name_to_user_agent(monkeypatch) -> None:

--- a/examples/motherduck_arrow_reads.py
+++ b/examples/motherduck_arrow_reads.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, cast
 
 from sqlalchemy import create_engine, text
 
@@ -12,7 +13,7 @@ def main() -> None:
 
     with engine.connect().execution_options(duckdb_arrow=True) as conn:
         result = conn.execute(text("select 1 as value"))
-        arrow_table = result.arrow
+        arrow_table = cast(Any, result).arrow
         print(arrow_table)
         print(arrow_table.to_pandas())
 


### PR DESCRIPTION
## Summary

This PR extracts the connection-configuration preparation logic from `Dialect.connect` into a focused `_prepare_connection_params` helper.

The existing `connect` method handled URL config merging, dialect-only query filtering, MotherDuck path-query extraction, default database selection, MotherDuck token/default handling, application-name extraction, and external DuckDB setting separation inline. That made the setup path harder to test directly and made future changes to connection parameter normalization more likely to be validated only through a mocked `connect` call.

The refactor keeps the existing mutation contract for `cparams`, but moves that preparation into a small helper before `Dialect.connect` proceeds with user-agent setup, DuckDB connection creation, extension loading, filesystem registration, and external config application.

## User Impact

There is no intended behavior change. Users should see the same connection arguments, MotherDuck URL query handling, config splitting, and custom user-agent behavior as before.

## Validation

- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check`
- `uv run --extra devtools pre-commit run --all-files`

I also fixed a type-checking issue in `examples/motherduck_arrow_reads.py` by casting the dialect-specific Arrow result access, matching the existing test pattern for `result.arrow`.
