### PR TITLE
[codex] simplify execute retry wrapper

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -1566,11 +1566,9 @@ class Dialect(PGDialect_psycopg2):
 
     def _execute_with_retry(
         self,
-        cursor: Any,
         statement: str,
-        parameters: Any,
         context: Optional[Any],
-        executor: Any,
+        executor: Callable[[], Any],
     ) -> Any:
         options = self._get_execution_options(context)
         retry_count = int(options.get("duckdb_retry_count", 0) or 0)
@@ -1602,7 +1600,7 @@ class Dialect(PGDialect_psycopg2):
                 self, cursor, statement, parameters, context
             )
 
-        self._execute_with_retry(cursor, statement, parameters, context, executor)
+        self._execute_with_retry(statement, context, executor)
 
     def do_execute_no_params(
         self, cursor: Any, statement: str, context: Optional[Any] = None
@@ -1610,7 +1608,7 @@ class Dialect(PGDialect_psycopg2):
         def executor() -> Any:
             return DefaultDialect.do_execute_no_params(self, cursor, statement, context)
 
-        self._execute_with_retry(cursor, statement, None, context, executor)
+        self._execute_with_retry(statement, context, executor)
 
     def _pg_class_filter_scope_schema(
         self,

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -287,6 +287,30 @@ def test_retry_on_transient_select() -> None:
     assert cursor.calls == 2
 
 
+def test_retry_on_transient_select_without_params() -> None:
+    dialect = Dialect()
+
+    class DummyCursor:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def execute(self, statement):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("HTTP Error: 503 Service Unavailable")
+            return None
+
+    class DummyContext:
+        execution_options = {
+            "duckdb_retry_on_transient": True,
+            "duckdb_retry_count": 1,
+        }
+
+    cursor = DummyCursor()
+    dialect.do_execute_no_params(cursor, "select 1", context=DummyContext())
+    assert cursor.calls == 2
+
+
 def test_motherduck_url_builder_moves_path_params() -> None:
     with pytest.warns(DeprecationWarning, match="dbinstance_inactivity_ttl"):
         url = MotherDuckURL(


### PR DESCRIPTION
## Summary

This is a small targeted refactor in the statement execution retry path. The retry helper previously accepted the cursor and parameters from both `do_execute` and `do_execute_no_params`, even though it only needed the SQL statement, execution context, and callable that performs the default SQLAlchemy execution.

## Issue and user impact

The duplicate call shape made the two execution paths look more different than they are and left unused arguments in the shared retry helper. That does not change runtime behavior today, but it makes future retry-path changes easier to get wrong because the helper signature suggests it owns cursor or parameter handling when it does not.

## Root cause

`_execute_with_retry()` was introduced as a wrapper around the caller-provided executor, but retained arguments from both call sites instead of narrowing its contract to the values it actually reads.

## Fix

The helper now takes only `statement`, `context`, and a typed zero-argument executor. Both `do_execute` and `do_execute_no_params` delegate through the same smaller contract. I also added a focused unit test for retrying transient failures through `do_execute_no_params`, complementing the existing parameterized `do_execute` coverage.

## Validation

- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check`
- `uv run --extra devtools pre-commit run --all-files`
