### PR TITLE
[codex] refactor type field rendering

### DIFF
--- a/duckdb_sqlalchemy/datatypes.py
+++ b/duckdb_sqlalchemy/datatypes.py
@@ -13,10 +13,11 @@ from typing import Any, Dict, Optional, Tuple, Type
 import duckdb
 from packaging.version import Version
 from sqlalchemy import exc, util
-from sqlalchemy.dialects.postgresql.base import PGIdentifierPreparer, PGTypeCompiler
+from sqlalchemy.dialects.postgresql.base import PGTypeCompiler
 from sqlalchemy.engine import Dialect
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import sqltypes, type_api
+from sqlalchemy.sql.compiler import IdentifierPreparer
 from sqlalchemy.sql.type_api import TypeEngine
 from sqlalchemy.types import BigInteger, Integer, SmallInteger, String
 
@@ -305,20 +306,18 @@ def register_extension_types() -> None:
 def visit_struct(
     instance: Struct,
     compiler: PGTypeCompiler,
-    identifier_preparer: PGIdentifierPreparer,
     **kw: Any,
 ) -> str:
-    return "STRUCT" + struct_or_union(instance, compiler, identifier_preparer, **kw)
+    return "STRUCT" + struct_or_union(instance, compiler, **kw)
 
 
 @compiles(Union, "duckdb")  # type: ignore[misc]
 def visit_union(
     instance: Union,
     compiler: PGTypeCompiler,
-    identifier_preparer: PGIdentifierPreparer,
     **kw: Any,
 ) -> str:
-    return "UNION" + struct_or_union(instance, compiler, identifier_preparer, **kw)
+    return "UNION" + struct_or_union(instance, compiler, **kw)
 
 
 @compiles(Variant, "duckdb")  # type: ignore[misc]
@@ -342,25 +341,15 @@ def visit_geometry(
 def struct_or_union(
     instance: typing.Union[Union, Struct],
     compiler: PGTypeCompiler,
-    identifier_preparer: PGIdentifierPreparer,
+    identifier_preparer: Optional[IdentifierPreparer] = None,
     **kw: Any,
 ) -> str:
-    fields = getattr(instance, "_fields", None)
-    if fields is None:
-        fields = _normalize_fields(instance.fields)
+    fields = instance._fields
     if fields is None:
         raise exc.CompileError(f"DuckDB {repr(instance)} type requires fields")
-    return "({})".format(
-        ", ".join(
-            "{} {}".format(
-                identifier_preparer.quote_identifier(key),
-                process_type(
-                    value, compiler, identifier_preparer=identifier_preparer, **kw
-                ),
-            )
-            for key, value in (fields.items() if isinstance(fields, dict) else fields)
-        )
-    )
+    if identifier_preparer is None:
+        identifier_preparer = compiler.dialect.identifier_preparer
+    return _render_struct_or_union_fields(fields, compiler, identifier_preparer, **kw)
 
 
 def process_type(
@@ -369,6 +358,24 @@ def process_type(
     **kw: Any,
 ) -> str:
     return compiler.process(type_api.to_instance(value), **kw)
+
+
+def _render_struct_or_union_fields(
+    fields: Tuple[Tuple[str, TypeEngine], ...],
+    compiler: PGTypeCompiler,
+    identifier_preparer: IdentifierPreparer,
+    **kw: Any,
+) -> str:
+    rendered_fields = (
+        "{} {}".format(
+            identifier_preparer.quote_identifier(key),
+            process_type(
+                value, compiler, identifier_preparer=identifier_preparer, **kw
+            ),
+        )
+        for key, value in fields
+    )
+    return "({})".format(", ".join(rendered_fields))
 
 
 @compiles(Map, "duckdb")  # type: ignore[misc]

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -1187,9 +1187,28 @@ def test_struct_or_union_requires_fields() -> None:
 
     struct = dt.Struct({"first name": String, "age": Integer})
     rendered = dt.struct_or_union(struct, compiler, preparer)
-    assert rendered.startswith("(")
-    assert rendered.endswith(")")
-    assert '"first name"' in rendered
+    assert rendered == '("first name" VARCHAR, "age" INTEGER)'
+
+
+@pytest.mark.parametrize(
+    ("field_type", "expected"),
+    [
+        (
+            dt.Struct({"first name": String, "age": Integer}),
+            'STRUCT("first name" VARCHAR, "age" INTEGER)',
+        ),
+        (
+            dt.Union({"name": String, "age": Integer}),
+            'UNION("name" VARCHAR, "age" INTEGER)',
+        ),
+    ],
+)
+def test_field_type_compilers_render_normalized_fields(
+    field_type: Any, expected: str
+) -> None:
+    dialect = Dialect()
+
+    assert dialect.type_compiler.process(field_type) == expected
 
 
 def test_duckdb_reflection_filters_share_schema_database_builder() -> None:


### PR DESCRIPTION
## Summary

This PR keeps the nested DuckDB type compiler path small and easier to reason about by centralizing STRUCT and UNION field rendering after fields have already been normalized.

Before this change, `struct_or_union()` still carried compatibility logic for dict-style fields even though `Struct` and `Union` instances normalize their fields during construction. That meant the compile path repeated normalization concerns and made direct type compiler use less obvious. It also exposed an edge case where calling the dialect type compiler directly for `Struct` or `Union` could fail because the custom compiler functions expected SQLAlchemy to pass an identifier preparer explicitly.

The refactor now uses the normalized `_fields` tuple as the single source of truth, derives the dialect identifier preparer from the compiler when the caller does not provide one, and moves the field-list rendering into `_render_struct_or_union_fields()`. The existing `struct_or_union()` helper remains available for tests and internal use, but it is smaller and no longer needs to branch over dict versus tuple inputs.

For users, the intended compiled SQL is unchanged: field names are still quoted and field types still use the dialect type compiler. The practical improvement is that direct compiler usage for these field types now works consistently and the rendering code has one clear path.

## Validation

- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py::test_struct_or_union_requires_fields duckdb_sqlalchemy/tests/test_core_units.py::test_field_type_compilers_render_normalized_fields -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check`
- `uv run --extra dev --extra devtools pre-commit run --all-files`
