### PR TITLE
[codex] update duckdb 1.5.4 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,10 @@ repos:
         language: python
         files: ^duckdb_sqlalchemy/(?!tests/).*\.py$
         additional_dependencies:
-          - "ty==0.0.49"
+          - "ty==0.0.54"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.15.17'
+    rev: 'v0.15.20'
     hooks:
       - id: ruff
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ preserved from the upstream project for historical context.
 
 - expose MotherDuck `md_user_info().c.region` and Flight run `config` columns in the SQLAlchemy table-function helpers
 - document one-off `md_run_flight(config=...)` overrides and selecting effective Flight run config
+- route `motherduck_enable_server_side_temp_tables` through the MotherDuck startup URL parameter bucket
 
 ### Bug Fixes
 
@@ -20,7 +21,8 @@ preserved from the upstream project for historical context.
 
 ### Tooling
 
-- bump the local `ty` pin to `0.0.49` and the Ruff pre-commit hook to `0.15.17` after validating the current checks against the latest non-breaking releases
+- extend the validated compatibility matrix to DuckDB 1.5.4 and SQLAlchemy 2.0.51
+- bump the local `ty` pin to `0.0.54` and the Ruff pre-commit hook to `0.15.20` after validating the current checks against the latest non-breaking releases
 - refresh the locked development dependency set to the latest non-breaking transitive releases within existing version caps
 
 ## [1.5.3](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.2.2...v1.5.3) (2026-06-02)

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Current direction in this repository:
 | Component | Supported versions |
 | --- | --- |
 | Python | 3.9+ |
-| SQLAlchemy | 2.0.45+ (CI-tested: 2.0.45, 2.0.50) |
-| DuckDB | 0.5.0+ (CI-tested currently: 1.3.0 to 1.5.3) |
+| SQLAlchemy | 2.0.45+ (CI-tested: 2.0.45, 2.0.51) |
+| DuckDB | 0.5.0+ (CI-tested currently: 1.3.0 to 1.5.4) |
 
 ## Install
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,8 @@ engine = create_engine("duckdb:///analytics.db", connect_args={"read_only": True
 - Unknown but syntactically valid keys are forwarded to DuckDB and may fail with
   DuckDB's native "unrecognized configuration parameter" error.
 - MotherDuck path-query options (`attach_mode`, `session_name`, `access_mode`,
-  and related keys) are handled specially for `md:` URLs. See
+  `motherduck_enable_server_side_temp_tables`, and related keys) are handled
+  specially for `md:` URLs. See
   [motherduck.md](motherduck) and [connection-urls.md](connection-urls).
 
 ## Preload extensions

--- a/docs/motherduck.md
+++ b/docs/motherduck.md
@@ -70,6 +70,7 @@ Parameters that are treated as part of the database string:
 - `dbinstance_inactivity_ttl` (preferred; `motherduck_dbinstance_inactivity_ttl`
   remains supported but is deprecated)
 - `saas_mode` (`pgendpoint` is supported when you need PG endpoint-compatible routing)
+- `motherduck_enable_server_side_temp_tables`
 - `cache_buster`
 
 For backward compatibility the dialect also accepts `session_hint`,

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -1525,7 +1525,9 @@ class Dialect(PGDialect_psycopg2):
         view_name = f"__duckdb_sa_bulk_{uuid.uuid4().hex}"
         dbapi_conn = cursor.connection
         dbapi_conn.register(view_name, data)
-        preparer = getattr(context, "identifier_preparer", self.identifier_preparer)
+        preparer: Any = getattr(
+            context, "identifier_preparer", self.identifier_preparer
+        )
         target = preparer.format_table(table)
         columns = ", ".join(preparer.quote(col) for col in column_names)
         insert_sql = (

--- a/duckdb_sqlalchemy/motherduck.py
+++ b/duckdb_sqlalchemy/motherduck.py
@@ -43,6 +43,9 @@ SESSION_NAME_KEY = "session_name"
 MOTHERDUCK_SESSION_HINT_KEY = "motherduck_session_hint"
 MOTHERDUCK_SESSION_NAME_KEY = "motherduck_session_name"
 MOTHERDUCK_SAAS_MODE_KEY = "motherduck_saas_mode"
+MOTHERDUCK_ENABLE_SERVER_SIDE_TEMP_TABLES_KEY = (
+    "motherduck_enable_server_side_temp_tables"
+)
 TOKEN_ALIAS_KEY = "token"
 MOTHERDUCK_OAUTH_TOKEN_KEY = "motherduck_oauth_token"
 OAUTH_TOKEN_ALIAS_KEY = "oauth_token"
@@ -73,6 +76,7 @@ MOTHERDUCK_PATH_QUERY_KEYS = {
     MOTHERDUCK_DBINSTANCE_INACTIVITY_TTL_KEY,
     "saas_mode",
     MOTHERDUCK_SAAS_MODE_KEY,
+    MOTHERDUCK_ENABLE_SERVER_SIDE_TEMP_TABLES_KEY,
     "cache_buster",
     CACHE_BUST_ALIAS_KEY,
 }

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -425,6 +425,7 @@ def test_get_core_config_includes_motherduck_keys() -> None:
         "slt",
         "attach_mode",
         "saas_mode",
+        "motherduck_enable_server_side_temp_tables",
         "session_name",
         "motherduck_session_name",
         "session_hint",
@@ -1812,6 +1813,7 @@ def test_motherduck_url_merges_and_overrides_across_inputs() -> None:
         path_query={"session_name": "old-team", "user": "alice"},
         session_name="new-team",
         attach_mode=("single", "workspace"),
+        motherduck_enable_server_side_temp_tables=True,
         memory_limit="1GB",
         cache_buster=None,
     )
@@ -1823,6 +1825,7 @@ def test_motherduck_url_merges_and_overrides_across_inputs() -> None:
         "session_name": ["new-team"],
         "user": ["alice"],
         "attach_mode": ["single", "workspace"],
+        "motherduck_enable_server_side_temp_tables": ["true"],
     }
     assert url.query == {"memory_limit": "1GB", "saas_mode": "true"}
 
@@ -1995,6 +1998,7 @@ def test_extract_path_query_from_config_mutates_and_normalizes_aliases() -> None
         "tls": "off",
         "session_name": "team-a",
         "motherduck_dbinstance_inactivity_ttl": "10m",
+        "motherduck_enable_server_side_temp_tables": True,
         "threads": 4,
     }
 
@@ -2007,6 +2011,7 @@ def test_extract_path_query_from_config_mutates_and_normalizes_aliases() -> None
         "tls": "off",
         "session_name": "team-a",
         "dbinstance_inactivity_ttl": "10m",
+        "motherduck_enable_server_side_temp_tables": "true",
     }
     assert config == {"threads": 4}
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,9 +38,10 @@ def group(title: str) -> Generator[None, None, None]:
         "1.5.1",
         "1.5.2",
         "1.5.3",
+        "1.5.4",
     ],
 )
-@nox.parametrize("sqlalchemy", ["2.0.45", "2.0.50"])
+@nox.parametrize("sqlalchemy", ["2.0.45", "2.0.51"])
 def tests(session: nox.Session, duckdb: str, sqlalchemy: str) -> None:
     tests_core(session, duckdb, sqlalchemy)
 
@@ -48,7 +49,7 @@ def tests(session: nox.Session, duckdb: str, sqlalchemy: str) -> None:
 @nox.session(py=["3.9"])
 def nightly(session: nox.Session) -> None:
     session.skip("DuckDB nightly installs are broken right now")
-    tests_core(session, "master", "2.0.50")
+    tests_core(session, "master", "2.0.51")
 
 
 def tests_core(session: nox.Session, duckdb: str, sqlalchemy: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
     "nox>=2026.4.10,<2027.0.0",
     "pyarrow>=22.0.0; python_version >= '3.10'",
     "pytest>=8.0.0,<10.0.0",
-    "ty==0.0.49",
+    "ty==0.0.54",
     "hypothesis>=6.75.2,<7.0.0",
     "github-action-utils>=1.1.0,<2.0.0",
     "pandas>=1,<2.0; python_version < '3.12'",

--- a/uv.lock
+++ b/uv.lock
@@ -655,7 +655,7 @@ requires-dist = [
     { name = "pytz", marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=2024.2" },
     { name = "sqlalchemy", specifier = ">=2.0.45" },
     { name = "toml", marker = "extra == 'dev'", specifier = ">=0.10.2,<0.11.0" },
-    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.49" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.54" },
 ]
 provides-extras = ["dev", "devtools"]
 
@@ -664,7 +664,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2151,27 +2151,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.49"
+version = "0.0.54"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/8d/37cb91808069509d43a2a11743e12f1e854fd808dbef2203309d256718cd/ty-0.0.49.tar.gz", hash = "sha256:0a027bd0c9c75d035641a365d087ad883446057f9be0b9826251c2aecafbf145", size = 5884753, upload-time = "2026-06-12T03:08:20.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/c6/2ea90406d82cf82b0a68725130da2cc9de161bfa883c7dee4f0d94dbf3ce/ty-0.0.54.tar.gz", hash = "sha256:b6b3cfe174f27744413c898b2488ca52ea76070637095de131698e506b455055", size = 6009000, upload-time = "2026-06-25T17:53:17.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/de/9237c6a96356612dd0393db1e94cf21f903616adf3a3701bf3da6e4adc92/ty-0.0.49-py3-none-linux_armv6l.whl", hash = "sha256:12c0c4310b936d762a8586c210b53d4fa4bb361a04429afa89bf84b922e5e065", size = 11834671, upload-time = "2026-06-12T03:07:53.062Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/15/daf5a14a5e07012277d450c75325c94614e2acfec4c620c881486118c410/ty-0.0.49-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:737bfdc2caf9712a8580944dcdc80a450a37a4f2bc83c8fa9b7433b374f9e471", size = 11589570, upload-time = "2026-06-12T03:08:25.779Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/58/30bdf98436488aca25f0763bf7f92a061528d42461b686453029e845e4c5/ty-0.0.49-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ab90c1baf3b1701d282fce4b02fa552a962d109f8972c46ef6b22429503bfea4", size = 10985236, upload-time = "2026-06-12T03:08:36.664Z" },
-    { url = "https://files.pythonhosted.org/packages/22/45/ece503e4a1396e13a1a9a0cde51afe476a6506a1d557eeadf8ad45c83bc0/ty-0.0.49-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4ce8ecf6ba6fc79bd137cc0557a754f7e5f2dfe9436412551d480d680e248ad", size = 11504302, upload-time = "2026-06-12T03:08:01.664Z" },
-    { url = "https://files.pythonhosted.org/packages/17/dc/5d09333d289dfbca1804eaade125c9e8a1a992a2a592a8b80c5e9b589ca9/ty-0.0.49-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:10d85c6865c984e78661e0bd20b180514b4a289739224e84816e342bdf381e04", size = 11626629, upload-time = "2026-06-12T03:08:06.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/36/155f41c9dd7237c4b609211f29f77755a139ee6218605dadc7fe21d5e3c8/ty-0.0.49-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d96a67a206619e01fa92f35a22267ec634bba62be24b1d0e947020cc179995b", size = 12074481, upload-time = "2026-06-12T03:08:09.643Z" },
-    { url = "https://files.pythonhosted.org/packages/96/4c/998ee13cd5045f1f8b36982de7343163832ac53f27debe01b0de0e8bd968/ty-0.0.49-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3de9f648564e0a66344ef397770387cb0d093735f8679d2c5a08a4741e79814d", size = 12678042, upload-time = "2026-06-12T03:08:39.319Z" },
-    { url = "https://files.pythonhosted.org/packages/85/c9/9a505aba85c41ce54cbcaa14f8d79aa084b86151d2d70df11c4655b92898/ty-0.0.49-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5779179ab397d15f8c9dbb8f506ec1b1745f54eac639982f76ef3ce538943b50", size = 12316194, upload-time = "2026-06-12T03:08:18.023Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b8/ded37fb93503294abbc83c36470bb1413bea05048b745881d4470b518a06/ty-0.0.49-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792d4974e93cc09bd32f934586080bbbe21b8e777099cb521cb2de18b68a49f0", size = 12145507, upload-time = "2026-06-12T03:07:56.505Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/07/392e80d78f02445f695b815bb9eb0fffacda68b03faee38c900f7b990815/ty-0.0.49-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:727bda86deb136073e525c2e78d60e38aedcce5d80579170844a52bbf7c1440d", size = 12365967, upload-time = "2026-06-12T03:08:12.553Z" },
-    { url = "https://files.pythonhosted.org/packages/50/d3/31b0c2a7fbedd3373e389cb1d81b8d2128f6f868fafb46557736a6f9aca8/ty-0.0.49-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4f2fc2bc4a8d2ff1cca59fd94772cabdfec4062d47a0b3a0784be46d94d0540b", size = 11475283, upload-time = "2026-06-12T03:08:28.334Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/5b/329e101638920b468a3bb63059c9f66ef99b44aac501222c44832a507321/ty-0.0.49-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:3724bd9badef333321578b6a941fbc571ebf49141ec2356a8590fbe4c9aa588d", size = 11645343, upload-time = "2026-06-12T03:08:15.246Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/76/c897e615e32f80ca81c8c1bc49b9a1f72ff9e3cfea0f8345ba505fe28472/ty-0.0.49-py3-none-musllinux_1_2_i686.whl", hash = "sha256:166c6eb52ee4af3c5a9bb267d165d93000daa55c6758cd8ff3199741fb75917d", size = 11725585, upload-time = "2026-06-12T03:08:33.915Z" },
-    { url = "https://files.pythonhosted.org/packages/59/e1/fdb42ee239f618800842681af5bb8598117e74512c10974a8b7b9086a898/ty-0.0.49-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:91e81d832c287b05782ee32eb1b801f62c1fa08df37d589d2b88c3f1d51c9731", size = 12237261, upload-time = "2026-06-12T03:08:31.105Z" },
-    { url = "https://files.pythonhosted.org/packages/98/0f/a2d6a5fc9d0786cbeb3c200786da4e18c203589be3984bb5def83ca92320/ty-0.0.49-py3-none-win32.whl", hash = "sha256:7186af5ca9829d1f5d8916bcf767b8e819bfbf61b1b8ec843bb3fc699cb502e1", size = 11100789, upload-time = "2026-06-12T03:07:59.092Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/9d/473ac8bc57b5a2d121da893bf9dd74a118efb19a01d711df1a6e397f05cc/ty-0.0.49-py3-none-win_amd64.whl", hash = "sha256:ae2142fc126a01effcca0c222908b0e6654b5ba1266d4e4d406e4866aef8e1d1", size = 12204644, upload-time = "2026-06-12T03:08:04.327Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/a2/8959249da951ba3977fee20e688d28678b8a1d30a9ed4464228a85d45853/ty-0.0.49-py3-none-win_arm64.whl", hash = "sha256:75d5e2e7649765f31f4bed6c8adb149a75b18edd3fa6336dac4d0efc1a66466f", size = 11558965, upload-time = "2026-06-12T03:08:23.012Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/26/a83e688e108a29a8630d7075bae47b72614cfa275c88b3166575ca0a8af0/ty-0.0.54-py3-none-linux_armv6l.whl", hash = "sha256:0365ea133d6b028952c22e6412a00da9739bc3b538df3c0a61972bf64d8558f1", size = 11616164, upload-time = "2026-06-25T17:52:29.174Z" },
+    { url = "https://files.pythonhosted.org/packages/85/89/9f3374f9eef0267aed5efbd5544e47cfa6affc94236d929e878a780cf7d7/ty-0.0.54-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0de0cf48918609a3996cc2a4e18e8028fc4d2446bb82df822e9737f53bb9afee", size = 11351250, upload-time = "2026-06-25T17:52:32.181Z" },
+    { url = "https://files.pythonhosted.org/packages/28/11/e0e3f542a6de0e0dd5f503215527f8d9fc141426bd52dbe98fce927ff831/ty-0.0.54-py3-none-macosx_11_0_arm64.whl", hash = "sha256:57c7c6c1fcd2aa29cd40117142c0d45a2b0e6c42817ef58ea8dcb5f59d6ea802", size = 10872162, upload-time = "2026-06-25T17:52:35.206Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b0/fa369840f1ccd391971f693a8f86c445eb1a0fad61a6e0e773f0871a7a6f/ty-0.0.54-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc179be5a070c5dc7785a5e108eece2ab216978a91f91e11661308749a6c28ee", size = 11419826, upload-time = "2026-06-25T17:52:37.942Z" },
+    { url = "https://files.pythonhosted.org/packages/62/5f/8fbf9b7147cf08cc96cc9f84b9699ae7c7a0a1eb0a4c3d912261351b1cbb/ty-0.0.54-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5a0a764e2261f9292adf14bbc91b9d7ef7ee7c00b8f3d9f2563f19ae3605109b", size = 11411732, upload-time = "2026-06-25T17:52:41.124Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ce/53aa78828f98ce396d5cc0f0878d990c0d70f6bf7704105232399315952f/ty-0.0.54-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2259e1a1f744a5f20f079dcc4061c1464001c75f255aaca7316e422f8f5e5e09", size = 12039318, upload-time = "2026-06-25T17:52:43.981Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/5654d4d20376a73cd2e9df8178515c466ff9b2bda15748ee5810c955a265/ty-0.0.54-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8674617617399d4fdd568b3e3a8f87a913df525c80691d732b0744b571b341c8", size = 12625562, upload-time = "2026-06-25T17:52:46.578Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f7/982be4abde816c821c6aeaba133dc34b5346eebbb29dadbf77b8ee46dad9/ty-0.0.54-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e949f7bbfa80a9fa00968924028aa673a505faa234b0b9d1241b7d34373eae14", size = 12175175, upload-time = "2026-06-25T17:52:49.176Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8b/371fa3d121a1d9c8806a997ec5aa7b6a91912044d936594e6cf04d197471/ty-0.0.54-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a0ce5af9eefe636888377d8ab8ea817239ed96de64fede62c4e5331ae16db5c", size = 11945921, upload-time = "2026-06-25T17:52:51.983Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/76/cab1ff8f6029b657b3fed59add1a2f188df6af26b6d649a6c789139dd88d/ty-0.0.54-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ad329d1942e23ee428948e673b2a50249f27e164220075b0a2ef8169029c8423", size = 12269965, upload-time = "2026-06-25T17:52:54.697Z" },
+    { url = "https://files.pythonhosted.org/packages/31/2f/c14b36cacacf7cc5ae40c862c34c07fadeba85cb93fd8f328cdac2029270/ty-0.0.54-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6e43124e6ac4cb9702d99facb28c6b2f2574c8a4b8f59eae2632eef4962e3439", size = 11370742, upload-time = "2026-06-25T17:52:57.233Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1b/9e55bb273d3ea8efe165a73e34ae92220593e4dbfe665b8283be9d3eadea/ty-0.0.54-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:994ede70fc1b6f0efc29d0f1fc0d819630bed1d2610eac2e9dabb2840f3f3bf9", size = 11432346, upload-time = "2026-06-25T17:52:59.898Z" },
+    { url = "https://files.pythonhosted.org/packages/db/16/402e8d2b1ab1020a25774f22ec0ba4378617758197278c1ddbc093b64854/ty-0.0.54-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b1d048df26abb433acc5b3bcef214167c7dc9e3341f8f200a3c59702516a0ed0", size = 11707341, upload-time = "2026-06-25T17:53:02.678Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ca/220599403e1dc864109402c88e22e8793108ec3be41576cd044772023d94/ty-0.0.54-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:651e90094d41c4add3d616e0f2c1c881c6700a2ae3ac191c023c665050ff2cdc", size = 12053427, upload-time = "2026-06-25T17:53:05.983Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a9/f08df843e3d4422184a847829eb103c49a6118eed7024969a1a706de1c5e/ty-0.0.54-py3-none-win32.whl", hash = "sha256:7e876c9b5130afc6b6e46035a2eecca9b563b78249030296e1089922428d5415", size = 11044018, upload-time = "2026-06-25T17:53:09.582Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/26/230719333d79fae599e3c2da5ac35e36786cdd6c4b4f2a5d5450ce171dc7/ty-0.0.54-py3-none-win_amd64.whl", hash = "sha256:f478476f3222807b4d92f15c5298a8c242f2ed17c724da75f4a8c6b522b4f29a", size = 12107765, upload-time = "2026-06-25T17:53:12.2Z" },
+    { url = "https://files.pythonhosted.org/packages/28/68/b5fcb35ceebffab3e8898bd25e51d0bb77a0c43c50b7a8e3fae56125e4f5/ty-0.0.54-py3-none-win_arm64.whl", hash = "sha256:01ab9eb8c0802d35ae73fa08e4e037963250ee5ee6aa7ed8c8b994e5495db5ef", size = 11498510, upload-time = "2026-06-25T17:53:14.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR refreshes duckdb-sqlalchemy for the current public DuckDB/MotherDuck 1.5.4 release line and the latest SQLAlchemy 2.0.x release available during the maintenance pass.

It extends the nox compatibility matrix to DuckDB 1.5.4 and SQLAlchemy 2.0.51, updates the README compatibility table, and refreshes the local type/lint tooling pins to ty 0.0.54 and Ruff 0.15.20. The uv lockfile is updated for the ty pin.

It also adds `motherduck_enable_server_side_temp_tables` to the MotherDuck startup/path-query bucket. That keeps the option in the database path where MotherDuck client instance and startup parameters are expected, while preserving the existing split between startup routing parameters and regular DuckDB config parameters.

## User impact

Users can pass `motherduck_enable_server_side_temp_tables` through `MotherDuckURL`, URL query parameters, or `connect_args["config"]` and have the dialect route it consistently for `md:` connections. The compatibility matrix now exercises the latest DuckDB and SQLAlchemy releases instead of stopping at DuckDB 1.5.3 and SQLAlchemy 2.0.50.

## Root cause

The dialect keeps a curated list of MotherDuck startup parameters so those keys are moved into the database path before calling `duckdb.connect`. The new server-side temp table option was not yet in that list, so it would have been treated as regular config instead of startup/path identity input.

## Validation

- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py -q`
- `uv run --extra dev --with duckdb==1.5.4 --with sqlalchemy==2.0.51 python -c '...'` local engine and MotherDuckURL routing smoke
- `uv run --extra dev --with duckdb==1.5.4 --with sqlalchemy==2.0.51 pytest -q`
- `uv run --extra dev ty check --ignore unresolved-import --exclude duckdb_sqlalchemy/tests/** duckdb_sqlalchemy/`
- `uv run --extra devtools pre-commit run --all-files`
- `uv run --extra dev nox -s "tests-3.14(sqlalchemy='2.0.51', duckdb='1.5.4')"`
