### PR TITLE
release 1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ preserved from the upstream project for historical context.
 
 ## Unreleased
 
+## [1.5.4](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.3...v1.5.4) (2026-06-26)
+
 ### Features
 
 - expose MotherDuck `md_user_info().c.region` and Flight run `config` columns in the SQLAlchemy table-function helpers
@@ -16,6 +18,7 @@ preserved from the upstream project for historical context.
 
 ### Bug Fixes
 
+- restore SQLAlchemy 2.0.0+ compatibility by using a reflection fallback on early 2.0 releases
 - reject empty MotherDuck Flight config keys before compiling Flight helper calls
 - reject invalid MotherDuck Flight config map keys and NUL-containing values before compiling Flight helper calls
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Current direction in this repository:
 | Component | Supported versions |
 | --- | --- |
 | Python | 3.9+ |
-| SQLAlchemy | 2.0.45+ (CI-tested: 2.0.45, 2.0.51) |
+| SQLAlchemy | 2.0.0+ on Python <3.14; 2.0.45+ on Python 3.14+ (CI-tested: 2.0.0, 2.0.51) |
 | DuckDB | 0.5.0+ (CI-tested currently: 1.3.0 to 1.5.4) |
 
 ## Install

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -126,7 +126,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.3"
+    __version__ = "1.5.4"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")
@@ -1177,6 +1177,79 @@ class Dialect(PGDialect_psycopg2):
                 column_names.append(None)
         return expressions, column_names
 
+    def _reflect_pg_type_compat(
+        self,
+        format_type: Optional[str],
+        *,
+        type_description: str,
+    ) -> Any:
+        reflect_type = getattr(super(), "_reflect_type", None)
+        if reflect_type is not None:
+            return reflect_type(
+                format_type,
+                {},
+                {},
+                type_description=type_description,
+                collation=None,
+            )
+
+        if format_type is None:
+            util.warn(
+                "PostgreSQL format_type() returned NULL for %s" % type_description
+            )
+            return sqltypes.NULLTYPE
+
+        args_match = re.search(r"\((.*)\)$", format_type)
+        type_args: List[str]
+        if args_match and args_match.group(1):
+            type_args = [part.strip() for part in args_match.group(1).split(",")]
+        else:
+            type_args = []
+
+        type_name = re.sub(r"\(.*\)$", "", format_type).strip().lower()
+        schema_type = self.ischema_names.get(type_name)
+        args: Tuple[Any, ...] = ()
+        kwargs: Dict[str, Any] = {}
+
+        if type_name == "numeric" and len(type_args) == 2:
+            args = (int(type_args[0]), int(type_args[1]))
+        elif type_name == "double precision":
+            args = (53,)
+        elif type_name in (
+            "timestamp with time zone",
+            "time with time zone",
+        ):
+            kwargs["timezone"] = True
+            if len(type_args) == 1:
+                kwargs["precision"] = int(type_args[0])
+        elif type_name in (
+            "timestamp without time zone",
+            "time without time zone",
+            "time",
+        ):
+            kwargs["timezone"] = False
+            if len(type_args) == 1:
+                kwargs["precision"] = int(type_args[0])
+        elif type_name == "bit varying":
+            kwargs["varying"] = True
+            if len(type_args) == 1:
+                args = (int(type_args[0]),)
+        else:
+            try:
+                charlen = int(type_args[0])
+            except (IndexError, ValueError):
+                args = tuple(type_args)
+            else:
+                args = (charlen, *type_args[1:])
+
+        if schema_type is None:
+            util.warn(
+                "Did not recognize type '%s' of %s" % (type_name, type_description)
+            )
+            return sqltypes.NULLTYPE
+
+        return schema_type(*args, **kwargs)
+
     def _reflect_duckdb_data_type(
         self,
         data_type: str,
@@ -1214,12 +1287,9 @@ class Dialect(PGDialect_psycopg2):
         elif upper.startswith(("STRUCT(", "MAP(", "UNION(")):
             reflected = sqltypes.NULLTYPE
         else:
-            reflected = self._reflect_type(  # type: ignore[attr-defined]
+            reflected = self._reflect_pg_type_compat(
                 normalized,
-                {},
-                {},
                 type_description=type_description,
-                collation=None,
             )
 
         if dimensions:

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -150,7 +150,7 @@ def test_connect_keeps_token_in_config_and_moves_transport_options(monkeypatch) 
     }
     assert captured["config"]["token"] == "legacy-token"
     assert captured["config"]["threads"] == 4
-    assert captured["config"]["custom_user_agent"].startswith("duckdb-sqlalchemy/1.5.3")
+    assert captured["config"]["custom_user_agent"].startswith("duckdb-sqlalchemy/1.5.4")
 
 
 def test_prepare_connection_params_normalizes_config(
@@ -217,7 +217,7 @@ def test_connect_moves_application_name_to_user_agent(monkeypatch) -> None:
 
     assert "application_name" not in captured["config"]
     assert captured["config"]["threads"] == 4
-    assert captured["config"]["custom_user_agent"].startswith("duckdb-sqlalchemy/1.5.3")
+    assert captured["config"]["custom_user_agent"].startswith("duckdb-sqlalchemy/1.5.4")
     assert (
         "application_name(Analytics Worker)" in captured["config"]["custom_user_agent"]
     )

--- a/llms.txt
+++ b/llms.txt
@@ -20,5 +20,5 @@ Docs:
 
 Compatibility:
 - Python 3.9+
-- SQLAlchemy 1.3.22+ (2.x recommended)
+- SQLAlchemy 2.0.0+ on Python <3.14; 2.0.45+ on Python 3.14+
 - DuckDB 1.3.0+ (1.4.4 recommended)

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,8 +41,10 @@ def group(title: str) -> Generator[None, None, None]:
         "1.5.4",
     ],
 )
-@nox.parametrize("sqlalchemy", ["2.0.45", "2.0.51"])
+@nox.parametrize("sqlalchemy", ["2.0.0", "2.0.51"])
 def tests(session: nox.Session, duckdb: str, sqlalchemy: str) -> None:
+    if session.python == "3.14" and sqlalchemy == "2.0.0":
+        session.skip("SQLAlchemy 2.0.0 is not compatible with Python 3.14")
     tests_core(session, duckdb, sqlalchemy)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.3"
+version = "1.5.4"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},
@@ -27,7 +27,8 @@ classifiers = [
 ]
 dependencies = [
     "duckdb>=0.5.0",
-    "sqlalchemy>=2.0.45",
+    "sqlalchemy>=2.0.0; python_version < '3.14'",
+    "sqlalchemy>=2.0.45; python_version >= '3.14'",
     "packaging>=21",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -592,13 +592,14 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.3"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "duckdb", version = "1.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "packaging" },
-    { name = "sqlalchemy" },
+    { name = "sqlalchemy", marker = "python_full_version < '3.14'" },
+    { name = "sqlalchemy", version = "2.0.51", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 
 [package.optional-dependencies]
@@ -653,7 +654,8 @@ requires-dist = [
     { name = "pytest-remotedata", marker = "extra == 'dev'", specifier = ">=0.4.0,<0.5.0" },
     { name = "pytest-snapshot", marker = "extra == 'dev'", specifier = ">=0.9.0,<1.0.0" },
     { name = "pytz", marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=2024.2" },
-    { name = "sqlalchemy", specifier = ">=2.0.45" },
+    { name = "sqlalchemy", marker = "python_full_version < '3.14'", specifier = ">=2.0.0" },
+    { name = "sqlalchemy", marker = "python_full_version >= '3.14'", specifier = ">=2.0.45" },
     { name = "toml", marker = "extra == 'dev'", specifier = ">=0.10.2,<0.11.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.54" },
 ]


### PR DESCRIPTION
## Summary
- prepare the 1.5.4 package release metadata and changelog
- restore SQLAlchemy 2.0.0 compatibility for Python <3.14 with a reflection fallback, while keeping Python 3.14 on SQLAlchemy 2.0.45+
- update version assertions, docs compatibility text, nox matrix, and lockfile markers

## Why
This release ships the merged MotherDuck helper, Flight config validation, DuckDB 1.5.4 compatibility, and tooling updates since v1.5.3, plus restores compatibility for early SQLAlchemy 2.x releases where the PostgreSQL private reflection helper is unavailable.

## Verification
- uv lock
- uv run --extra dev pytest
- uv run --extra dev nox -s ty-3.11
- uv run --extra dev nox -s "tests-3.11(sqlalchemy='2.0.0', duckdb='1.5.4')"
- uv run --extra dev nox -s "tests-3.14(sqlalchemy='2.0.0', duckdb='1.5.4')" (skips unsupported SQLAlchemy/Python combo)
- uv run --extra dev --extra devtools pre-commit run --all-files
- uv run --with build python -m build
- uv run --with twine twine check dist/*