### PR TITLE
[codex] refactor bulk row shaping

### DIFF
--- a/duckdb_sqlalchemy/_bulk_insert.py
+++ b/duckdb_sqlalchemy/_bulk_insert.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any, Optional, Sequence, cast
 
-
-def _rows_use_mapping_shape(rows: Sequence[Any]) -> bool:
-    return bool(rows) and isinstance(rows[0], Mapping)
+from ._row_shape import infer_mapping_column_keys, rows_use_mapping_shape
 
 
 def infer_bulk_insert_column_keys(rows: Sequence[Any]) -> Optional[list[str]]:
-    if not _rows_use_mapping_shape(rows):
-        return None
-    return [str(key) for key in cast(Mapping[str, Any], rows[0]).keys()]
+    return infer_mapping_column_keys(rows)
 
 
 def build_bulk_insert_dataframe(
@@ -23,7 +18,7 @@ def build_bulk_insert_dataframe(
         return None
 
     try:
-        if _rows_use_mapping_shape(rows):
+        if rows_use_mapping_shape(rows):
             return pd.DataFrame.from_records(rows, columns=column_names)
         return pd.DataFrame(rows, columns=cast(Any, column_names))
     except Exception:
@@ -39,7 +34,7 @@ def build_bulk_insert_arrow_table(
         return None
 
     try:
-        if _rows_use_mapping_shape(rows):
+        if rows_use_mapping_shape(rows):
             table = pa.Table.from_pylist(rows)
             if column_names:
                 return table.select(column_names)

--- a/duckdb_sqlalchemy/_row_shape.py
+++ b/duckdb_sqlalchemy/_row_shape.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from itertools import chain
+from typing import Any, Optional, Tuple, Union, cast
+
+
+def rows_use_mapping_shape(rows: Sequence[Any]) -> bool:
+    return bool(rows) and isinstance(rows[0], Mapping)
+
+
+def infer_mapping_column_keys(rows: Sequence[Any]) -> Optional[list[str]]:
+    if not rows_use_mapping_shape(rows):
+        return None
+    return [str(key) for key in cast(Mapping[str, Any], rows[0]).keys()]
+
+
+def mapping_row_as_sequence(
+    row: Mapping[str, Any], columns: Sequence[str]
+) -> Sequence[Any]:
+    return [row.get(col) for col in columns]
+
+
+def rows_as_sequences(
+    first: Union[Mapping[str, Any], Sequence[Any]],
+    rows: Iterable[Union[Mapping[str, Any], Sequence[Any]]],
+    columns: Optional[Sequence[str]],
+) -> Tuple[Iterable[Sequence[Any]], Optional[Sequence[str]]]:
+    if isinstance(first, Mapping):
+        if columns is None:
+            columns = [str(col) for col in cast(Mapping[str, Any], first).keys()]
+
+        first_row = mapping_row_as_sequence(cast(Mapping[str, Any], first), columns)
+        remaining_rows = (
+            mapping_row_as_sequence(cast(Mapping[str, Any], row), columns)
+            for row in rows
+        )
+        return chain((first_row,), remaining_rows), columns
+
+    first_row = cast(Sequence[Any], first)
+    remaining_rows = (cast(Sequence[Any], row) for row in rows)
+    return chain((first_row,), remaining_rows), columns

--- a/duckdb_sqlalchemy/bulk.py
+++ b/duckdb_sqlalchemy/bulk.py
@@ -1,9 +1,9 @@
 import csv
 import tempfile
-from itertools import chain
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple, Union, cast
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple, Union
 
+from ._row_shape import rows_as_sequences
 from ._validation import (
     validate_dotted_identifier,
     validate_identifier,
@@ -160,20 +160,7 @@ def _copy_rows_as_sequences(
     rows: Iterable[Union[Mapping[str, Any], Sequence[Any]]],
     columns: Optional[Sequence[str]],
 ) -> Tuple[Iterable[Sequence[Any]], Optional[Sequence[str]]]:
-    if isinstance(first, Mapping):
-        if columns is None:
-            columns = [str(col) for col in cast(Mapping[str, Any], first).keys()]
-
-        def row_to_seq(row: Mapping[str, Any]) -> Sequence[Any]:
-            return [row.get(col) for col in columns or []]
-
-        first_row = row_to_seq(cast(Mapping[str, Any], first))
-        remaining_rows = (row_to_seq(cast(Mapping[str, Any], row)) for row in rows)
-        return chain((first_row,), remaining_rows), columns
-
-    first_row = cast(Sequence[Any], first)
-    remaining_rows = (cast(Sequence[Any], row) for row in rows)
-    return chain((first_row,), remaining_rows), columns
+    return rows_as_sequences(first, rows, columns)
 
 
 def copy_from_parquet(


### PR DESCRIPTION
## Summary

This refactors the internal bulk row-shaping logic used by the register-based bulk insert path and the public `copy_from_rows` helper.

Both code paths previously carried their own small assumptions for detecting mapping-shaped rows, inferring column order from the first mapping row, and converting mappings into positional row sequences. That made future changes to mapping-row behavior easy to apply in one path but miss in the other.

The root cause was that row shape handling lived inline in two different modules: `_bulk_insert.py` for the fast insert data builders, and `bulk.py` for CSV-backed row copy. The user-visible effect was not a current behavioral bug, but duplicated internal logic around a fragile ingestion boundary.

The fix adds a small internal `_row_shape.py` helper module for mapping-shape detection, mapping key inference, and mapping-to-sequence conversion. The existing public/internal entry points now delegate to that helper while preserving the same behavior and tests.

## Validation

- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py::test_copy_rows_as_sequences_infers_mapping_columns duckdb_sqlalchemy/tests/test_core_units.py::test_copy_rows_as_sequences_uses_explicit_mapping_columns duckdb_sqlalchemy/tests/test_execution_options.py::test_infer_bulk_insert_column_keys_handles_mapping_rows`
- `uv run --extra dev pytest`
- `uv run --extra devtools pre-commit run --all-files`
