### PR TITLE
release 1.5.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,4 @@ __marimo__/
 
 # Local Codex sandbox rules (machine-specific)
 .codex/rules/
+notes/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ preserved from the upstream project for historical context.
 
 ## Unreleased
 
+## [1.5.4.1](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.4...v1.5.4.1) (2026-07-01)
+
+### Bug Fixes
+
+- render autoincrement integer primary keys with an implicit DuckDB sequence (`DEFAULT nextval(...)`) instead of PostgreSQL's unsupported `SERIAL`, so `Column(Integer, primary_key=True)` works without an explicit `Sequence` ([#128](https://github.com/leonardovida/duckdb-sqlalchemy/issues/128))
+
 ## [1.5.4](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.3...v1.5.4) (2026-06-26)
 
 ### Features

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -128,7 +128,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.4"
+    __version__ = "1.5.4.1"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.4"
+version = "1.5.4.1"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -592,7 +592,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.4"
+version = "1.5.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Patch release for the SERIAL autoincrement fix (#128, #130).

- bump version to 1.5.4.1 (pyproject.toml, `__version__` fallback, uv.lock)
- add 1.5.4.1 changelog entry
- gitignore `notes/`