### PR TITLE
refactor: centralize reflection result defaults

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -15,6 +15,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -1406,6 +1407,20 @@ class Dialect(PGDialect_psycopg2):
     def _reflection_schema_key(self, schema: Optional[str]) -> Optional[str]:
         return schema
 
+    def _iter_reflection_results(
+        self,
+        schema: Optional[str],
+        table_names: Iterable[str],
+        reflected: Mapping[str, Any],
+        default_factory: Callable[[], Any],
+    ) -> Iterable[Tuple[Any, Any]]:
+        schema_key = self._reflection_schema_key(schema)
+        for table_name in table_names:
+            value = reflected.get(table_name)
+            if value is None:
+                value = default_factory()
+            yield (schema_key, table_name), value
+
     def _get_single_reflection_result(
         self,
         connection: "Connection",
@@ -1502,13 +1517,8 @@ class Dialect(PGDialect_psycopg2):
             }
             for row in constraint_rows
         }
-        schema_key = self._reflection_schema_key(schema)
-        return (
-            (
-                (schema_key, table_name),
-                constraints.get(table_name, ReflectionDefaults.pk_constraint()),
-            )
-            for table_name in table_names
+        return self._iter_reflection_results(
+            schema, table_names, constraints, ReflectionDefaults.pk_constraint
         )
 
     @cache  # type: ignore[call-arg]
@@ -1611,10 +1621,8 @@ class Dialect(PGDialect_psycopg2):
             if any(column_name is None for column_name in column_names):
                 reflected_index["expressions"] = expressions
             indexes[row["table_name"]].append(reflected_index)
-        schema_key = self._reflection_schema_key(schema)
-        return (
-            ((schema_key, table_name), indexes.get(table_name, []))
-            for table_name in table_names
+        return self._iter_reflection_results(
+            schema, table_names, indexes, ReflectionDefaults.indexes
         )
 
     def create_connect_args(self, url: SAURL) -> Tuple[tuple, dict]:

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -1362,6 +1362,31 @@ def test_reflection_fallback_returns_empty_only_for_existing_tables(
         )
 
 
+def test_iter_reflection_results_defaults_only_missing_tables() -> None:
+    dialect = Dialect()
+    default_calls = 0
+
+    def default_factory() -> list[Any]:
+        nonlocal default_calls
+        default_calls += 1
+        return []
+
+    results = list(
+        dialect._iter_reflection_results(
+            "analytics",
+            ["orders", "customers"],
+            {"orders": [{"name": "orders_pk"}]},
+            default_factory,
+        )
+    )
+
+    assert results == [
+        (("analytics", "orders"), [{"name": "orders_pk"}]),
+        (("analytics", "customers"), []),
+    ]
+    assert default_calls == 1
+
+
 def test_parse_duckdb_enum_labels_unquotes_escaped_strings() -> None:
     labels, enum_name = Dialect()._parse_duckdb_enum_labels(
         "ENUM('alpha', 'it''s fine')",


### PR DESCRIPTION
Centralize repeated reflection result shaping so multi-reflection methods share the same schema-key/default handling while keeping behavior unchanged.

### Codex description

- add a private iterator for reflection result tuples and lazy defaults
- reuse it for primary-key and index multi-reflection results
- cover missing-table default behavior with a focused unit test
