### PR TITLE
[codex] fix copy_from_rows header mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ preserved from the upstream project for historical context.
 
 ## Maintained in this fork
 
-## Unreleased
+## [1.5.4.2](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.4.1...v1.5.4.2) (2026-07-03)
 
 ### Features
 
 - expose MotherDuck Dive status metadata columns on `md_list_dives()`, `md_create_dive()`, `md_get_dive()`, and other summary-returning Dive helpers
+
+### Bug Fixes
+
+- reject `copy_from_rows(..., include_header=True)` for sequence rows without explicit `columns` instead of letting DuckDB treat the first data row as the header
+
+### Maintenance
+
+- centralize reflection result default handling for multi-reflection methods without changing public behavior
 
 ### Tooling
 

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -130,7 +130,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.4.1"
+    __version__ = "1.5.4.2"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/duckdb_sqlalchemy/bulk.py
+++ b/duckdb_sqlalchemy/bulk.py
@@ -233,16 +233,21 @@ def copy_from_rows(
     if first is None:
         return None
 
-    copy_options = {"header": include_header, **copy_options}
+    header = copy_options.pop("header", include_header)
+    copy_options = {"header": header, **copy_options}
 
     chunked_rows, columns = _copy_rows_as_sequences(first, iterator, columns)
+    if header and columns is None:
+        raise ValueError(
+            "copy_from_rows header mode requires columns for sequence rows"
+        )
     _copy_rows_as_csv_chunks(
         connection,
         table,
         chunked_rows,
         columns=columns,
         chunk_size=chunk_size,
-        include_header=include_header,
+        include_header=header,
         copy_options=copy_options,
     )
     return None

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -1521,6 +1521,38 @@ def test_copy_from_rows_sequence_uses_explicit_columns_and_chunks() -> None:
     assert rows == [(1, "one"), (2, "two"), (3, "three")]
 
 
+def test_copy_from_rows_sequence_header_requires_columns() -> None:
+    conn = duckdb.connect(":memory:")
+    conn.execute("CREATE TABLE safe(i INTEGER, label VARCHAR)")
+
+    with pytest.raises(ValueError, match="header mode requires columns"):
+        copy_from_rows(
+            conn,
+            "safe",
+            [(1, "one"), (2, "two")],
+            include_header=True,
+        )
+
+    rows = conn.execute("SELECT i, label FROM safe ORDER BY i").fetchall()
+    assert rows == []
+
+
+def test_copy_from_rows_header_option_writes_header_with_columns() -> None:
+    conn = duckdb.connect(":memory:")
+    conn.execute("CREATE TABLE safe(i INTEGER, label VARCHAR)")
+
+    copy_from_rows(
+        conn,
+        "safe",
+        [(1, "one"), (2, "two")],
+        columns=["i", "label"],
+        header=True,
+    )
+
+    rows = conn.execute("SELECT i, label FROM safe ORDER BY i").fetchall()
+    assert rows == [(1, "one"), (2, "two")]
+
+
 def test_copy_rows_as_sequences_infers_mapping_columns() -> None:
     rows, columns = duckdb_sqlalchemy.bulk._copy_rows_as_sequences(
         {"id": 1, "label": "one"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.4.1"
+version = "1.5.4.2"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.4.1"
+version = "1.5.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -684,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.4"
+version = "3.29.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -699,9 +699,9 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
     "python_full_version == '3.10.*'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ee/29c668c50888588c432a702f7c2e8ee8a0c9e5286028d91f170308d6b2e9/filelock-3.29.5.tar.gz", hash = "sha256:6e6034c57a00a020e767f2614a5539863f056de7e7991d6d1473aef7ff73f156", size = 68927, upload-time = "2026-07-03T03:50:31.818Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e3/f1fae3647d170919c2cf2a898e77e7d1a4e5c7cae0aed7bb4bd3f5ebff6f/filelock-3.29.5-py3-none-any.whl", hash = "sha256:8af830889ba3a0ffcefbd6c7d2af8a54012058103771f2e10848222f476a1693", size = 45073, upload-time = "2026-07-03T03:50:30.445Z" },
 ]
 
 [[package]]
@@ -1808,7 +1808,7 @@ version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.29.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "filelock", version = "3.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "platformdirs", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -2191,7 +2191,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.29.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "filelock", version = "3.29.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "platformdirs", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "python-discovery" },


### PR DESCRIPTION
## Summary

This fixes a `copy_from_rows()` header-mode edge case and prepares the `1.5.4.2` patch release.

`copy_from_rows()` now treats `include_header=True` and the raw `header=True` COPY option consistently: it writes a header only when column names are available, and it raises a clear `ValueError` for sequence rows without explicit `columns` instead of letting DuckDB interpret the first data row as a header.

## Issue and user impact

Before this change, callers could pass sequence rows with `include_header=True` and no `columns`. Because there were no column names to write, the generated CSV file started with the first data row while the COPY command still used `HEADER TRUE`. DuckDB then treated that first row as the header and loaded only the remaining rows.

That is a silent data-loss bug for bulk row ingestion.

## Root cause

The helper used `include_header` to decide whether to write a CSV header, but it always passed the effective DuckDB `header` option through to `COPY`. Sequence-shaped input without explicit `columns` has no header names available, so header-mode COPY could be enabled without an actual header line.

## Fix

- Derive one effective header flag from `include_header` or the raw `header` COPY option.
- Use that same flag for both CSV writing and DuckDB COPY options.
- Reject header mode for sequence rows without explicit `columns` before any temporary CSV is loaded.
- Add regression coverage for the rejected data-loss case and for `header=True` with explicit columns.
- Bump package metadata and changelog entries for `1.5.4.2`.
- Refresh the locked transitive `filelock` development dependency from `3.29.4` to `3.29.5` within existing version constraints.

## Validation

- Smoke reproduced the old behavior: sequence rows with `include_header=True` loaded only the second row.
- Smoke after the fix confirms the call raises before loading rows and `header=True` with explicit columns loads correctly.
- `uv lock --check`
- `uv run --extra dev pytest duckdb_sqlalchemy/tests/test_core_units.py -k 'copy_from_rows or copy_rows_as_sequences' -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ty check --ignore unresolved-import --exclude 'duckdb_sqlalchemy/tests/**' duckdb_sqlalchemy/`
- `uv run --extra devtools pre-commit run --all-files`
- `uv run --extra dev nox -s "tests-3.14(sqlalchemy='2.0.51', duckdb='1.5.4')"`
- `git diff --check`
- `uv run --with build --with twine python -m build`
- `uv run --with twine twine check dist/*`

## Release plan

After this PR is merged and CI is green, create GitHub release `v1.5.4.2` so the publish workflow ships the patch to PyPI.
