### PR TITLE
refactor: centralize implicit sequence ddl

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -716,28 +716,25 @@ def _implicit_sequence_ddl_name(preparer: IdentifierPreparer, column: Any) -> st
     return name
 
 
-def _create_implicit_sequences(target: Any, connection: Any, **kw: Any) -> None:
+def _execute_implicit_sequence_ddl(
+    target: Any, connection: Any, statement_prefix: str
+) -> None:
     if connection.dialect.name != "duckdb":
         return
     preparer = connection.dialect.identifier_preparer
     for column in target.columns:
         if _column_needs_implicit_sequence(column):
             connection.exec_driver_sql(
-                "CREATE SEQUENCE IF NOT EXISTS "
-                f"{_implicit_sequence_ddl_name(preparer, column)}"
+                f"{statement_prefix} {_implicit_sequence_ddl_name(preparer, column)}"
             )
+
+
+def _create_implicit_sequences(target: Any, connection: Any, **kw: Any) -> None:
+    _execute_implicit_sequence_ddl(target, connection, "CREATE SEQUENCE IF NOT EXISTS")
 
 
 def _drop_implicit_sequences(target: Any, connection: Any, **kw: Any) -> None:
-    if connection.dialect.name != "duckdb":
-        return
-    preparer = connection.dialect.identifier_preparer
-    for column in target.columns:
-        if _column_needs_implicit_sequence(column):
-            connection.exec_driver_sql(
-                "DROP SEQUENCE IF EXISTS "
-                f"{_implicit_sequence_ddl_name(preparer, column)}"
-            )
+    _execute_implicit_sequence_ddl(target, connection, "DROP SEQUENCE IF EXISTS")
 
 
 event.listen(sa_schema.Table, "before_create", _create_implicit_sequences)

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -6,7 +6,17 @@ from urllib.parse import parse_qs
 
 import duckdb
 import pytest
-from sqlalchemy import Integer, String, create_engine, pool, select, text
+from sqlalchemy import (
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    pool,
+    select,
+    text,
+)
 from sqlalchemy import exc as sa_exc
 from sqlalchemy.engine import URL as SAURL
 
@@ -1294,6 +1304,47 @@ def test_connectionwrapper_close_marks_closed() -> None:
 
     assert wrapper.closed is True
     assert conn.closed is True
+
+
+@pytest.mark.parametrize(
+    ("handler", "expected_statement"),
+    [
+        (
+            duckdb_sqlalchemy._create_implicit_sequences,
+            "CREATE SEQUENCE IF NOT EXISTS events_id_seq",
+        ),
+        (
+            duckdb_sqlalchemy._drop_implicit_sequences,
+            "DROP SEQUENCE IF EXISTS events_id_seq",
+        ),
+    ],
+)
+def test_implicit_sequence_event_handlers_share_ddl_execution(
+    handler: Any, expected_statement: str
+) -> None:
+    table = Table(
+        "events",
+        MetaData(),
+        Column("id", Integer, primary_key=True),
+        Column("name", String),
+    )
+
+    class DummyConnection:
+        def __init__(self) -> None:
+            self.dialect = Dialect()
+            self.statements: list[str] = []
+
+        def exec_driver_sql(self, statement: str) -> None:
+            self.statements.append(statement)
+
+    connection = DummyConnection()
+    handler(table, connection)
+
+    assert connection.statements == [expected_statement]
+
+    connection.dialect.name = "postgresql"
+    handler(table, connection)
+    assert connection.statements == [expected_statement]
 
 
 def test_map_processors(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Centralizes the duplicated implicit autoincrement sequence lifecycle so create and drop callbacks share the same dialect guard, column selection, identifier preparation, and execution path.

### Codex description

- add one internal executor for implicit sequence DDL
- keep the existing create and drop event callbacks as thin wrappers
- cover both SQL paths and the non-DuckDB no-op behavior