### PR TITLE
fix: reflect dotted schema names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
           - "ty==0.0.65"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: 'v0.16.0'
+    rev: 'v0.16.1'
     hooks:
       - id: ruff
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ preserved from the upstream project for historical context.
 
 ## Maintained in this fork
 
+## [1.5.4.7](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.4.6...v1.5.4.7) (2026-07-31)
+
+### Bug Fixes
+
+- reflect valid quoted DuckDB schema names containing dots without crashing or splitting quoted identifier components
+
+### Tooling
+
+- update Ruff to 0.16.1 and refresh locked development dependencies within existing version constraints
+
 ## [1.5.4.6](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.4.5...v1.5.4.6) (2026-07-30)
 
 ### Bug Fixes

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -137,7 +137,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.4.6"
+    __version__ = "1.5.4.7"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")
@@ -672,14 +672,18 @@ class DuckDBIdentifierPreparer(PGIdentifierPreparer):
         Get database name and schema name from schema if it contains a database name
             Format:
               <db_name>.<schema_name>
-              db_name and schema_name are double quoted if contains spaces or double quotes
+              Components may be double quoted to preserve spaces, dots, or quotes.
         """
-        database_name, schema_name = None, name
-        if name is not None and "." in name:
-            database_name, schema_name = (
-                max(s) for s in re.findall(r'"([^.]+)"|([^.]+)', name)
-            )
-        return database_name, schema_name
+        if name is None:
+            return None, None
+        identifiers = self.unformat_identifiers(name)
+        if len(identifiers) == 1:
+            return None, identifiers[0]
+        if len(identifiers) == 2:
+            return identifiers[0], identifiers[1]
+        raise ValueError(
+            "DuckDB schema names must contain at most a database and schema"
+        )
 
     def format_schema(self, name: str) -> str:
         """Prepare a quoted schema name."""
@@ -950,8 +954,8 @@ class Dialect(PGDialect_psycopg2):
             """
         rs = connection.execute(text(s))
 
-        qs = self.identifier_preparer.quote_schema
-        return [qs(".".join(nspname)) for nspname in rs]
+        quote = self.identifier_preparer.quote
+        return [".".join(quote(identifier) for identifier in nspname) for nspname in rs]
 
     def _build_query_where(
         self,

--- a/duckdb_sqlalchemy/tests/test_basic.py
+++ b/duckdb_sqlalchemy/tests/test_basic.py
@@ -186,6 +186,7 @@ def test_get_schema_names(inspector: Inspector, session: Session) -> None:
     # Using multi-line strings because of all the single and double quotes flying around...
     cmds = [
         """CREATE SCHEMA "quack quack" """,
+        """CREATE SCHEMA "schema.with.dot" """,
         """CREATE SCHEMA "daffy duck"."you're "" despicable" """,
     ]
     for cmd in cmds:
@@ -200,6 +201,7 @@ def test_get_schema_names(inspector: Inspector, session: Session) -> None:
         '"daffy duck"."you\'re "" despicable"',
         "memory.main",
         'memory."quack quack"',
+        'memory."schema.with.dot"',
         "system.information_schema",
         "system.main",
         "temp.main",
@@ -213,6 +215,17 @@ def test_get_schema_names(inspector: Inspector, session: Session) -> None:
             }
         )
     assert names == expected
+
+
+def test_reflect_schema_with_dot(inspector: Inspector, session: Session) -> None:
+    session.execute(text('CREATE SCHEMA "schema.with.dot"'))
+    session.execute(text('CREATE TABLE "schema.with.dot".records (id INTEGER)'))
+    session.commit()
+
+    schema = 'memory."schema.with.dot"'
+    assert inspector.get_table_names(schema=schema) == ["records"]
+    assert inspector.has_table("records", schema=schema)
+    assert inspector.get_columns("records", schema=schema)[0]["name"] == "id"
 
 
 @mark.skipif(

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -641,10 +641,22 @@ def test_identifier_preparer_separate_and_format_schema() -> None:
 
     assert preparer._separate("db.schema") == ("db", "schema")
     assert preparer._separate('"my db"."my schema"') == ("my db", "my schema")
+    assert preparer._separate('"db.with.dot"."schema.with.dot"') == (
+        "db.with.dot",
+        "schema.with.dot",
+    )
+    assert preparer._separate('"db""quote"."schema""quote"') == (
+        'db"quote',
+        'schema"quote',
+    )
     assert preparer._separate("schema") == (None, "schema")
 
     formatted = preparer.format_schema('"my db".main')
     assert formatted == '"my db".main'
+    assert (
+        preparer.format_schema('"db.with.dot"."schema.with.dot"')
+        == '"db.with.dot"."schema.with.dot"'
+    )
 
 
 def test_identifier_preparer_reserved_words_are_cached(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.4.6"
+version = "1.5.4.7"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -556,7 +556,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.4.6"
+version = "1.5.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -1559,7 +1559,7 @@ version = "0.2.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "posthog", version = "6.9.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "posthog", version = "7.34.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "posthog", version = "7.35.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/36/59ef0a4be1e99dbe3a389fc4b200005f32dffa6dfd6e2ebd1eed6b3ce450/ploomber-core-0.2.27.tar.gz", hash = "sha256:d48bc826e382d095eaa776f67c86786f6473bfc8507a1b1b3671d4b48ddce070", size = 22390, upload-time = "2025-07-21T16:53:47.594Z" }
@@ -1598,7 +1598,7 @@ wheels = [
 
 [[package]]
 name = "posthog"
-version = "7.34.0"
+version = "7.35.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1619,9 +1619,9 @@ dependencies = [
     { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/c1/a51567ea78c5e9c77abbc863088f82e79f908e500d3441292a11abe8ad6a/posthog-7.34.0.tar.gz", hash = "sha256:c5f0e9a07536867bea3b5a233378b1a3f7c69ec36c5770581147f7be4fd91005", size = 390645, upload-time = "2026-07-30T09:50:07.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/f7/479cbb1c4d24c1cbcf45a06d98fc03f47fdb725069756f3394421ded0d3c/posthog-7.35.1.tar.gz", hash = "sha256:ac39c36d401a79d9e8997c6b9cce80a233780eb1718fe879b0c835f4171f0390", size = 392147, upload-time = "2026-07-31T08:11:23.619Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/de/a4209376d58d7d4081dff754c3bf4f99186d0d07aaca33d19e52d2a50fdf/posthog-7.34.0-py3-none-any.whl", hash = "sha256:6a277de901c240fc66926d64b4ba4a04d0212653ae616c0219168bf6addc36fb", size = 463553, upload-time = "2026-07-30T09:50:05.068Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a3/00d3f3af98bd1e7bcaa5198b971e911784509a15f1130c064be496745a03/posthog-7.35.1-py3-none-any.whl", hash = "sha256:1e852bf3bb9c076b989432bb2913b2e44bb9c9e8cac1ebdc886b17e7ddb1c6ad", size = 465193, upload-time = "2026-07-31T08:11:21.818Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix valid quoted DuckDB database and schema identifiers containing dots during SQLAlchemy reflection, and prepare patch release 1.5.4.7.

### Codex description

- parse multipart schemas with SQLAlchemy quote-aware identifier handling
- quote reflected catalog and schema components independently
- add live regression coverage and refresh compatible development dependencies