### PR TITLE
fix: support DuckDB prerelease reflection

### DIFF
--- a/.github/workflows/pythonapp.yaml
+++ b/.github/workflows/pythonapp.yaml
@@ -85,3 +85,20 @@ jobs:
           python -m pip install SQLAlchemy==2.1.0b3
       - name: Run SQLAlchemy prerelease tests
         run: pytest -q
+
+  duckdb_prerelease:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          allow-prereleases: true
+      - name: Install DuckDB prerelease
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+          python -m pip install --pre --upgrade duckdb
+      - name: Run DuckDB prerelease tests
+        run: pytest -q

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -1376,6 +1376,8 @@ class Dialect(PGDialect_psycopg2):
             reflected = sqltypes.JSON()
         elif upper == "BLOB":
             reflected = sqltypes.LargeBinary()
+        elif upper == "TIMESTAMPTZ_NS":
+            reflected = sqltypes.TIMESTAMP(timezone=True)
         elif upper.startswith(("DECIMAL(", "NUMERIC(")) and normalized.endswith(")"):
             precision_scale = normalized[normalized.index("(") + 1 : -1]
             parts = [part.strip() for part in precision_scale.split(",", 1)]
@@ -1389,7 +1391,9 @@ class Dialect(PGDialect_psycopg2):
                 normalized, enum_rows.get(data_type_id)
             )
             reflected = sqltypes.Enum(*labels, name=enum_name)
-        elif upper.startswith(("STRUCT(", "MAP(", "UNION(")):
+        elif upper == "STRUCT" or upper.startswith(
+            ("STRUCT(", "MAP(", "UNION(", "TUPLE(")
+        ):
             reflected = sqltypes.NULLTYPE
         else:
             reflected = self._reflect_pg_type_compat(

--- a/duckdb_sqlalchemy/tests/test_datatypes.py
+++ b/duckdb_sqlalchemy/tests/test_datatypes.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session, declarative_base
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.types import FLOAT, JSON
 
+from .. import Dialect
 from .._supports import duckdb_version, has_uhugeint_support
 from ..datatypes import Map, Struct, Variant, types
 
@@ -293,18 +294,44 @@ def test_all_types_reflection(engine: Engine) -> None:
     importorskip("sqlalchemy", "1.4.0")
     importorskip("duckdb", "0.5.1")
 
-    with warnings.catch_warnings() as capture, engine.connect() as conn:
+    with warnings.catch_warnings(record=True) as capture, engine.connect() as conn:
         conn.execute(text("create table t2 as select * from test_all_types()"))
         table = Table("t2", MetaData(), autoload_with=conn)
         for col in table.columns:
             name = col.name
             if name.endswith("_enum") and duckdb_version < Version("0.7.1"):
                 continue
-            if "struct" in name or "map" in name or "union" in name:
+            if any(
+                nested_type in name
+                for nested_type in ("struct", "map", "union", "tuple")
+            ):
                 assert col.type == sqltypes.NULLTYPE, name
             else:
                 assert col.type != sqltypes.NULLTYPE, name
         assert not capture
+
+
+def test_timestamptz_ns_reflection() -> None:
+    reflected = Dialect()._reflect_duckdb_data_type(
+        "TIMESTAMPTZ_NS",
+        None,
+        {},
+        "test timestamp",
+    )
+
+    assert isinstance(reflected, sqltypes.TIMESTAMP)
+    assert reflected.timezone is True
+
+
+def test_tuple_reflection_is_deliberately_unsupported() -> None:
+    reflected = Dialect()._reflect_duckdb_data_type(
+        "TUPLE(INTEGER, VARCHAR)",
+        None,
+        {},
+        "test tuple",
+    )
+
+    assert reflected == sqltypes.NULLTYPE
 
 
 def test_nested_types(engine: Engine, session: Session) -> None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,13 +50,18 @@ def tests(session: nox.Session, duckdb: str, sqlalchemy: str) -> None:
     tests_core(session, duckdb, sqlalchemy)
 
 
-@nox.session(py=["3.9"])
+@nox.session(py=["3.11"])
 def nightly(session: nox.Session) -> None:
-    session.skip("DuckDB nightly installs are broken right now")
-    tests_core(session, "master", "2.1.0b3")
+    tests_core(session, "master", "2.1.0b3", remote_data=False)
 
 
-def tests_core(session: nox.Session, duckdb: str, sqlalchemy: str) -> None:
+def tests_core(
+    session: nox.Session,
+    duckdb: str,
+    sqlalchemy: str,
+    *,
+    remote_data: bool = True,
+) -> None:
     with group(f"{session.name} - Install"):
         session.install("-e", ".[dev]")
         operator = "==" if sqlalchemy.count(".") == 2 else "~="
@@ -66,7 +71,7 @@ def tests_core(session: nox.Session, duckdb: str, sqlalchemy: str) -> None:
         else:
             session.install(f"duckdb=={duckdb}")
     with group(f"{session.name} Test"):
-        session.run(
+        pytest_args = [
             "pytest",
             "--junitxml=results.xml",
             "--cov",
@@ -74,7 +79,11 @@ def tests_core(session: nox.Session, duckdb: str, sqlalchemy: str) -> None:
             "xml:coverage.xml",
             "--verbose",
             "-rs",
-            "--remote-data",
+        ]
+        if remote_data:
+            pytest_args.append("--remote-data")
+        session.run(
+            *pytest_args,
             env={
                 "SQLALCHEMY_WARN_20": "true",
             },


### PR DESCRIPTION
DuckDB prerelease builds expose new temporal and nested catalog types that the dialect should handle without warnings or failed reflection.

### Codex description

- reflect `TIMESTAMPTZ_NS` as a timezone-aware SQLAlchemy timestamp
- deliberately classify unnamed `TUPLE` and empty `STRUCT` values as unsupported nested types
- restore local and hosted DuckDB prerelease test coverage on a supported Python version