### PR TITLE
fix: preserve timezone type reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ preserved from the upstream project for historical context.
 
 ## Maintained in this fork
 
+## [1.5.5.1](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.5...v1.5.5.1) (2026-08-18)
+
+### Bug Fixes
+
+- preserve timezone semantics when reflecting DuckDB `TIMESTAMPTZ` and `TIMETZ` columns so copied SQLAlchemy metadata does not recreate them without time zones ([#152](https://github.com/leonardovida/duckdb-sqlalchemy/pull/152))
+
+### Compatibility
+
+- support DuckDB 1.6 prerelease `TIMESTAMPTZ_NS`, unnamed `TUPLE`, and empty `STRUCT` catalog types without failed reflection or unexpected warnings ([#151](https://github.com/leonardovida/duckdb-sqlalchemy/pull/151))
+
+### Tooling
+
+- update the stable SQLAlchemy matrix to 2.0.52, `ty` to 0.0.72, Ruff to 0.16.3, and Codecov Action to v7 ([#150](https://github.com/leonardovida/duckdb-sqlalchemy/pull/150))
+- restore local and hosted DuckDB prerelease coverage on supported Python versions ([#151](https://github.com/leonardovida/duckdb-sqlalchemy/pull/151))
+
 ## [1.5.5](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.4.7...v1.5.5) (2026-08-09)
 
 ### Maintenance

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -137,7 +137,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.5"
+    __version__ = "1.5.5.1"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")
@@ -1376,8 +1376,14 @@ class Dialect(PGDialect_psycopg2):
             reflected = sqltypes.JSON()
         elif upper == "BLOB":
             reflected = sqltypes.LargeBinary()
-        elif upper == "TIMESTAMPTZ_NS":
+        elif upper in {
+            "TIMESTAMPTZ",
+            "TIMESTAMPTZ_NS",
+            "TIMESTAMP WITH TIME ZONE",
+        }:
             reflected = sqltypes.TIMESTAMP(timezone=True)
+        elif upper in {"TIMETZ", "TIME WITH TIME ZONE"}:
+            reflected = sqltypes.TIME(timezone=True)
         elif upper.startswith(("DECIMAL(", "NUMERIC(")) and normalized.endswith(")"):
             precision_scale = normalized[normalized.index("(") + 1 : -1]
             parts = [part.strip() for part in precision_scale.split(",", 1)]

--- a/duckdb_sqlalchemy/tests/test_datatypes.py
+++ b/duckdb_sqlalchemy/tests/test_datatypes.py
@@ -323,6 +323,29 @@ def test_timestamptz_ns_reflection() -> None:
     assert reflected.timezone is True
 
 
+def test_timezone_reflection_preserves_timezone_in_ddl(engine: Engine) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE timezone_source "
+                "(observed_at TIMESTAMPTZ, observed_time TIMETZ)"
+            )
+        )
+        source = Table("timezone_source", MetaData(), autoload_with=conn)
+
+    reflected_timestamp = source.c.observed_at.type
+    assert isinstance(reflected_timestamp, sqltypes.TIMESTAMP)
+    assert reflected_timestamp.timezone is True
+    reflected_time = source.c.observed_time.type
+    assert isinstance(reflected_time, sqltypes.TIME)
+    assert reflected_time.timezone is True
+
+    clone = source.to_metadata(MetaData(), name="timezone_clone")
+    ddl = str(schema.CreateTable(clone).compile(dialect=engine.dialect))
+    assert "TIMESTAMP WITH TIME ZONE" in ddl
+    assert "TIME WITH TIME ZONE" in ddl
+
+
 def test_tuple_reflection_is_deliberately_unsupported() -> None:
     reflected = Dialect()._reflect_duckdb_data_type(
         "TUPLE(INTEGER, VARCHAR)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.5"
+version = "1.5.5.1"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -611,7 +611,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.5"
+version = "1.5.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
DuckDB reports timezone-bearing aliases through canonical catalog names, and the dialect currently loses that timezone metadata when tables are reflected and recreated. This fixes the reflection contract and prepares the public 1.5.5.1 patch release.

### Codex description

- reflect DuckDB `TIMESTAMPTZ` and `TIMETZ` as timezone-aware SQLAlchemy types
- cover the real reflection-to-DDL round trip across supported DuckDB and SQLAlchemy versions
- bump package metadata to 1.5.5.1 and document all changes since v1.5.5