### PR TITLE
fix(motherduck): update Flight log columns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         language: python
         files: ^duckdb_sqlalchemy/(?!tests/).*\.py$
         additional_dependencies:
-          - "ty==0.0.73"
+          - "ty==0.0.74"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: 'v0.16.4'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ preserved from the upstream project for historical context.
 
 ### Bug Fixes
 
-- align `md_get_flight_logs` with MotherDuck's tabular `line_number`, `reported_at`, and `line` result while preserving the deprecated log helpers' historical `logs` accessor
-- declare the runtime timezone dependency needed to materialize `TIMESTAMPTZ` values such as Flight log timestamps in minimal installations
+- align `md_get_flight_logs` with MotherDuck's tabular `line_number`, `reported_at`, and `line` result while preserving the deprecated log helpers' historical `logs` accessor ([#155](https://github.com/leonardovida/duckdb-sqlalchemy/pull/155))
+- declare the runtime timezone dependency needed to materialize `TIMESTAMPTZ` values such as Flight log timestamps in minimal installations ([#155](https://github.com/leonardovida/duckdb-sqlalchemy/pull/155))
 
 ### Maintenance
 
@@ -19,7 +19,7 @@ preserved from the upstream project for historical context.
 
 ### Tooling
 
-- update `ty` to 0.0.74 and refresh compatible locked development dependencies
+- update `ty` to 0.0.74 and refresh compatible locked development dependencies ([#155](https://github.com/leonardovida/duckdb-sqlalchemy/pull/155))
 
 ## [1.5.5.2](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.5.1...v1.5.5.2) (2026-08-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ preserved from the upstream project for historical context.
 
 ## Maintained in this fork
 
+## [1.5.5.3](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.5.2...v1.5.5.3) (2026-08-26)
+
+### Bug Fixes
+
+- align `md_get_flight_logs` with MotherDuck's tabular `line_number`, `reported_at`, and `line` result while preserving the deprecated log helpers' historical `logs` accessor
+- declare the runtime timezone dependency needed to materialize `TIMESTAMPTZ` values such as Flight log timestamps in minimal installations
+
+### Maintenance
+
+- centralize visible DuckDB reflection row execution and filtering without changing reflection behavior ([#154](https://github.com/leonardovida/duckdb-sqlalchemy/pull/154))
+
+### Tooling
+
+- update `ty` to 0.0.74 and refresh compatible locked development dependencies
+
 ## [1.5.5.2](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.5.1...v1.5.5.2) (2026-08-21)
 
 ### Bug Fixes

--- a/docs/olap.md
+++ b/docs/olap.md
@@ -185,7 +185,7 @@ logs = md_get_flight_logs(
     flight_id="00000000-0000-0000-0000-000000000000",
     run_number=1,
 )
-logs_stmt = select(logs.c.logs)
+logs_stmt = select(logs.c.line_number, logs.c.reported_at, logs.c.line)
 
 versions = md_list_flight_versions(
     flight_id="00000000-0000-0000-0000-000000000000"
@@ -209,7 +209,9 @@ The older noun-style `md_flights`, `md_flight_runs`, `md_flight_logs`, and
 `md_flight_versions` helpers remain as deprecated compatibility aliases for the
 verb-style functions above. The `md_*job*` helper names also remain as
 deprecated compatibility aliases while preserving legacy `job_*` column access
-where possible.
+where possible. The deprecated `md_flight_logs` and `md_job_run_logs` helpers
+also preserve their historical `logs` column as an alias for the current
+line-by-line `line` result.
 
 ## Arrow results
 

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -137,7 +137,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.5.2"
+    __version__ = "1.5.5.3"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")

--- a/duckdb_sqlalchemy/olap.py
+++ b/duckdb_sqlalchemy/olap.py
@@ -112,7 +112,7 @@ MOTHERDUCK_FLIGHT_RUN_COLUMNS = (
     "cancelled_at",
     "exit_code",
 )
-MOTHERDUCK_FLIGHT_LOG_COLUMNS = ("logs",)
+MOTHERDUCK_FLIGHT_LOG_COLUMNS = ("line_number", "reported_at", "line")
 MOTHERDUCK_DELETE_FLIGHT_COLUMNS = ("deleted_count",)
 MOTHERDUCK_CANCEL_FLIGHT_RUN_COLUMNS = ("canceled_count",)
 MOTHERDUCK_DIVE_VERSION_COLUMNS = (
@@ -345,6 +345,7 @@ _JOB_VERSION_COLUMN_REPLACEMENTS = {
     "md_token_name": "access_token_name",
     "md_secret_names": "flight_secret_names",
 }
+_LEGACY_LOG_COLUMN_REPLACEMENTS = {"logs": "line"}
 _UNCHANGED_JOB_COLUMNS: Mapping[str, str] = {}
 
 
@@ -394,6 +395,23 @@ def _legacy_job_subquery(
     **kwargs: Any,
 ) -> Any:
     _warn_deprecated_job_helper(helper_name)
+    return _compatibility_subquery(
+        flight_helper,
+        columns=columns,
+        legacy_to_flight=legacy_to_flight,
+        default_columns=default_columns,
+        kwargs=_translate_job_parameters(kwargs),
+    )
+
+
+def _compatibility_subquery(
+    flight_helper: Any,
+    *,
+    columns: Optional[Iterable[str]],
+    legacy_to_flight: Mapping[str, str],
+    default_columns: Iterable[str],
+    kwargs: Mapping[str, Any],
+) -> Any:
     legacy_columns, flight_columns = _legacy_job_columns(
         columns,
         legacy_to_flight,
@@ -401,7 +419,7 @@ def _legacy_job_subquery(
     )
     flight_table = flight_helper(
         columns=flight_columns,
-        **_translate_job_parameters(kwargs),
+        **kwargs,
     )
     projections = []
     for legacy_column, flight_column in zip(legacy_columns, flight_columns):
@@ -541,7 +559,13 @@ def md_get_flight_logs(
 
 def md_flight_logs(*, columns: Optional[Iterable[str]] = None, **kwargs: Any) -> Any:
     _warn_deprecated_flight_helper("md_flight_logs", "md_get_flight_logs")
-    return md_get_flight_logs(columns=columns, **kwargs)
+    return _compatibility_subquery(
+        md_get_flight_logs,
+        columns=columns,
+        legacy_to_flight=_LEGACY_LOG_COLUMN_REPLACEMENTS,
+        default_columns=MOTHERDUCK_JOB_RUN_LOG_COLUMNS,
+        kwargs=kwargs,
+    )
 
 
 def md_list_flight_versions(
@@ -666,7 +690,7 @@ def md_job_run_logs(*, columns: Optional[Iterable[str]] = None, **kwargs: Any) -
         "md_job_run_logs",
         md_get_flight_logs,
         columns=columns,
-        legacy_to_flight=_UNCHANGED_JOB_COLUMNS,
+        legacy_to_flight=_LEGACY_LOG_COLUMN_REPLACEMENTS,
         default_columns=MOTHERDUCK_JOB_RUN_LOG_COLUMNS,
         **kwargs,
     )

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -877,7 +877,11 @@ def test_motherduck_flight_helpers_use_released_columns() -> None:
     assert list(olap.md_list_flight_runs().c.keys()) == list(
         olap.md_run_flight().c.keys()
     )
-    assert list(olap.md_get_flight_logs().c.keys()) == ["logs"]
+    assert list(olap.md_get_flight_logs().c.keys()) == [
+        "line_number",
+        "reported_at",
+        "line",
+    ]
     assert list(olap.md_list_flight_versions().c.keys()) == [
         "version_id",
         "flight_id",
@@ -931,6 +935,16 @@ def test_deprecated_flight_helpers_compile_to_released_functions(
     compiled = select(helper.c.value).select_from(helper).compile(dialect=Dialect())
 
     assert sql_function in str(compiled)
+
+
+def test_deprecated_flight_logs_aliases_tabular_line_column() -> None:
+    with pytest.warns(DeprecationWarning, match="md_get_flight_logs"):
+        logs = olap.md_flight_logs()
+
+    compiled = select(logs.c.logs).compile(dialect=Dialect())
+
+    assert "md_get_flight_logs" in str(compiled)
+    assert "anon_2.line AS logs" in str(compiled)
 
 
 @pytest.mark.parametrize(
@@ -1021,6 +1035,11 @@ def test_deprecated_motherduck_job_helpers_alias_flight_columns() -> None:
         assert list(olap.md_job_runs().c.keys()) == run_job_columns
     with pytest.warns(DeprecationWarning, match="md_job_run_logs"):
         assert list(olap.md_job_run_logs().c.keys()) == ["logs"]
+
+    with pytest.warns(DeprecationWarning, match="md_job_run_logs"):
+        logs = olap.md_job_run_logs()
+    compiled_logs = select(logs.c.logs).compile(dialect=Dialect())
+    assert "anon_2.line AS logs" in str(compiled_logs)
     with pytest.warns(DeprecationWarning, match="md_job_versions"):
         assert list(olap.md_job_versions().c.keys()) == [
             "version_id",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.5.2"
+version = "1.5.5.3"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},
@@ -30,6 +30,7 @@ dependencies = [
     "sqlalchemy>=2.0.0; python_version < '3.14'",
     "sqlalchemy>=2.0.45; python_version >= '3.14'",
     "packaging>=21",
+    "pytz>=2024.2",
 ]
 
 [project.urls]
@@ -47,12 +48,11 @@ dev = [
     "nox>=2026.4.10,<2027.0.0",
     "pyarrow>=22.0.0; python_version >= '3.10'",
     "pytest>=8.0.0,<10.0.0",
-    "ty==0.0.73",
+    "ty==0.0.74",
     "hypothesis>=6.75.2,<7.0.0",
     "github-action-utils>=1.1.0,<2.0.0",
     "pandas>=1,<2.0; python_version < '3.12'",
     "pandas>=2.2,<4.0; python_version >= '3.12'",
-    "pytz>=2024.2; python_version >= '3.12'",
     "jupysql>=0.11.1,<0.12.0",
     "pytest-cov>=7.1.0,<8.0.0",
     "pytest-remotedata>=0.4.0,<0.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -702,12 +702,13 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.5.2"
+version = "1.5.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "duckdb", version = "1.5.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "packaging" },
+    { name = "pytz" },
     { name = "sqlalchemy" },
 ]
 
@@ -731,7 +732,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-remotedata" },
     { name = "pytest-snapshot" },
-    { name = "pytz", marker = "python_full_version >= '3.12'" },
     { name = "toml" },
     { name = "ty" },
 ]
@@ -764,11 +764,11 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0,<8.0.0" },
     { name = "pytest-remotedata", marker = "extra == 'dev'", specifier = ">=0.4.0,<0.5.0" },
     { name = "pytest-snapshot", marker = "extra == 'dev'", specifier = ">=0.9.0,<1.0.0" },
-    { name = "pytz", marker = "python_full_version >= '3.12' and extra == 'dev'", specifier = ">=2024.2" },
+    { name = "pytz", specifier = ">=2024.2" },
     { name = "sqlalchemy", marker = "python_full_version < '3.14'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", marker = "python_full_version >= '3.14'", specifier = ">=2.0.45" },
     { name = "toml", marker = "extra == 'dev'", specifier = ">=0.10.2,<0.11.0" },
-    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.73" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.74" },
 ]
 provides-extras = ["dev", "devtools"]
 
@@ -2423,27 +2423,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.73"
+version = "0.0.74"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/90/c4e1bb4cead3b644c3e258a27f9b05c7dc5eb0ec96a4f5282194edae9e0d/ty-0.0.73.tar.gz", hash = "sha256:823d4ce0d237bfc7eb6bcee70842f2c0706113813a16951077840743712f4b74", size = 6712739, upload-time = "2026-08-19T03:12:43.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/0f/c767853e88567a2ec7e996dd95e3105b1bc62c95d103689311ef0f4a603c/ty-0.0.74.tar.gz", hash = "sha256:da14344fc8625fc9ff359bafb856ad575636ea86d9bb6a629b146bff27b380e6", size = 6786318, upload-time = "2026-08-22T15:05:54.054Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/0f/f5e1801e55cc631f2db193276675b30561b963a2403da832bffb5d100267/ty-0.0.73-py3-none-linux_armv6l.whl", hash = "sha256:90a946082bf9bc446b5e72973d9f4ff1222a240b2ca4c9e6eed61eb913e30810", size = 12715452, upload-time = "2026-08-19T03:12:06.673Z" },
-    { url = "https://files.pythonhosted.org/packages/54/32/515dd05074c213b433524ab97eb003b0132ae7e358e0d75633ba7a314ed8/ty-0.0.73-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b7d6b5c6a6db7ea95fbbc16af514ef44a27a29a2fe1dc798900790364d170209", size = 12301870, upload-time = "2026-08-19T03:12:08.924Z" },
-    { url = "https://files.pythonhosted.org/packages/50/4d/085b4889f0d4bbe4af8b96242d4a1cb209fff95967cfa239ea141983719b/ty-0.0.73-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dd6f657f463e01372d8688f235be164750c8db722c97da27fa4903aa8d40b203", size = 12111741, upload-time = "2026-08-19T03:12:11.067Z" },
-    { url = "https://files.pythonhosted.org/packages/95/f6/d6ec277cadfecf03ad4c18551b67c4c6eb7807a0560d801db14be99d7a89/ty-0.0.73-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc2de468e33fd44c9ff1c43473a7316f4289480f5cba8995a67b6d22aee39ca9", size = 12196124, upload-time = "2026-08-19T03:12:13.14Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b7/ce78d8707563af9cae9bbd25328bfbc4931035085bd20089adf0c418f70e/ty-0.0.73-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2942fa0ef795a66034cdc8d75a72f453442f3b58ff2f69b4da05b7b954765b55", size = 12488557, upload-time = "2026-08-19T03:12:15.252Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/e8/329b9851b23502758c5c98e8cc875ea2a1b4c9674b4ca3a86da56a5063d3/ty-0.0.73-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e0f1ef14f642e18ac4e7a616a2796dcf7a5d82e28cd17f9796494acc7c4aabb", size = 13215606, upload-time = "2026-08-19T03:12:17.225Z" },
-    { url = "https://files.pythonhosted.org/packages/36/38/67fedfd2cb77516ef0066b1642f487dba0eb3006493cf3475b15f5b8b228/ty-0.0.73-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16981e15fdceedb37d0aff76c5ac25914595dfee2675af95335550064251ad22", size = 13665497, upload-time = "2026-08-19T03:12:19.286Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/b3/154f4dd48ec5eebc186ab4b822c6e62f982fc5ddfd262d6e3903c2acba44/ty-0.0.73-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:644b2bec8a2e2e4957a942ae81d6cff5571c489bb5a8675e4d3886de537a694d", size = 13351231, upload-time = "2026-08-19T03:12:21.353Z" },
-    { url = "https://files.pythonhosted.org/packages/35/5f/d462496903fbe453fb76363f8478be929c8e6ff21e6928c57dcd7e5fa21f/ty-0.0.73-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:338d565be3186f50ff8e9d10483685549c2d23f0754485d5ede3b54f4319188a", size = 12782586, upload-time = "2026-08-19T03:12:23.667Z" },
-    { url = "https://files.pythonhosted.org/packages/87/52/ec6d24b74abe3ec324204c1c71e6d0c6c76a17ffc15fd51d603b0a302abe/ty-0.0.73-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:11c7b6d839309d2c102cb3a4c03d817176bbfab5b2fccc95a75ec5c9597421c9", size = 13247134, upload-time = "2026-08-19T03:12:25.956Z" },
-    { url = "https://files.pythonhosted.org/packages/26/20/cc74650fec56a54786c6d7c89e09576fcad3092be34cf21715d39a406a9b/ty-0.0.73-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:488572db7ff97fb50ea36a76250f2d617c9727d143da6c7bf0623276eb0fc507", size = 12309344, upload-time = "2026-08-19T03:12:28.122Z" },
-    { url = "https://files.pythonhosted.org/packages/89/bd/4b0a9087f4315d7fbadf77a3ce44c816cc9ffabed1ced06cc5be81fbc414/ty-0.0.73-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1b958ebceefbbf594e59eb8d3d55bbd033ce634026fcba3e4bc3179e78e45bb7", size = 12502319, upload-time = "2026-08-19T03:12:30.128Z" },
-    { url = "https://files.pythonhosted.org/packages/11/80/0a925074911fe111912ea29d9eed309bcc183f43d2fb3eef07db056a0beb/ty-0.0.73-py3-none-musllinux_1_2_i686.whl", hash = "sha256:91a32993b3c34e42c3f323ad6c0399cb596bd1c27e9b7f20db7cd64c1067b68e", size = 12753688, upload-time = "2026-08-19T03:12:32.433Z" },
-    { url = "https://files.pythonhosted.org/packages/24/6b/aeccaf89efbc2e112bd415340a22e2669ec998aa397242503e747b712ca4/ty-0.0.73-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bab8a19fbf51f479bddb2a12c5fabfe52f918a5590362321ed5d89b44eb62c15", size = 13069050, upload-time = "2026-08-19T03:12:35.398Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/3e/eae485fd86c1585943fd4e1746b0757b2da01e2c43136ebe8c686fe1c7f1/ty-0.0.73-py3-none-win32.whl", hash = "sha256:03347a612f0fa020b19bfd8dbd521db6ecc75d377a3e4d4f6e6c2e62871da4cc", size = 12053187, upload-time = "2026-08-19T03:12:37.565Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/01/9b8b983786e3ce34924e372e8b76b92b508273ab65c589fc7e88cc03ee17/ty-0.0.73-py3-none-win_amd64.whl", hash = "sha256:cedd05122ded0b5dcc55431a370e974b747f99c41c290a3d2ab8c1867f197519", size = 12693838, upload-time = "2026-08-19T03:12:39.483Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/88/25333bbfea6a5dc064371d2002d3d4807db90b84d5448f9106b2712b0fbc/ty-0.0.73-py3-none-win_arm64.whl", hash = "sha256:e47068f8369dea5d641a26a2ad0a947a320b02ff87099b07e95de0323245a4dc", size = 12443573, upload-time = "2026-08-19T03:12:41.449Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/95/6ded58bc97885c6d88fa1f9cd815031489200738f961cbf0466663213f80/ty-0.0.74-py3-none-linux_armv6l.whl", hash = "sha256:8969ef4e508debf00cf58f9ea85a539f799b1732c59cdfcecd037630b9755b30", size = 12790043, upload-time = "2026-08-22T15:05:05.015Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8a/5e323603b6ab8731144421877ee8a0f8ac5a5511e67857127caa09f6730e/ty-0.0.74-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51fb6cf5b98e1e1140825b2430943f78d744876a735231656eafbb4c3f7eca3c", size = 12371748, upload-time = "2026-08-22T15:05:08.609Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/ee72e08cb705281e8d8c42917dd577aa598a8a098008495fda5176ee3f6e/ty-0.0.74-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8ebe60b1f0a948c793d6c77fc9e9ddda599e4f023c04ab16e8e03bcb428c3fa0", size = 12282403, upload-time = "2026-08-22T15:05:11.448Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b3/fd935b694ff68bc278af50f7ad04770b36ce6306399baef7e1847b553a9d/ty-0.0.74-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa97f407a695c890a53615966a663c7d2167e2cabe88db7ca1a24d62635cdfc8", size = 12345164, upload-time = "2026-08-22T15:05:14.19Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5c/5b5825268e029ebb164c909780103dbbae367f069801410068bf1cef29b3/ty-0.0.74-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:673ddb733d4a0db31385ba1ed9ff1f6bd9dc5565413ce57b1ca5ac4c7803da5d", size = 12556646, upload-time = "2026-08-22T15:05:16.994Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e7/515914e571d62ce0101744fed3f881936eeb1b30dc37beb72b4f7ca1e289/ty-0.0.74-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1028e7c6b4f6145e9704552f43a5fffdcd51b42263ffdcd9c9677762bc395a4a", size = 13311653, upload-time = "2026-08-22T15:05:20.254Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/07/d1452babb6f9266c2122cabc095180b70ed306fb770b2996753814d2237d/ty-0.0.74-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:79841a8890493021fb308772474983316eb91f7b56cb227a6a05a06b262a36f0", size = 13768284, upload-time = "2026-08-22T15:05:23.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/60/8d4a2fc7842a47210a1cb0a16a187d9de39ad5d509a00fb74c1c073afcde/ty-0.0.74-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94859d321f3c6a6c8f7bfc3f40e8319cda7e6e012e613440f3dfd145d5010e2e", size = 13422306, upload-time = "2026-08-22T15:05:26.248Z" },
+    { url = "https://files.pythonhosted.org/packages/de/76/ebbc269a8c4efcc4d44624993bd188145f20d60ebda9680b15aaec42cc50/ty-0.0.74-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:970a8b2c09ff3be04c8a1c6767332d861be4fce85efe7bb205e4ade7c8655274", size = 12970637, upload-time = "2026-08-22T15:05:29.15Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/dd/b99f7236acbf856780ca1779a48143d2d9f2c24d7f531a0ce15a022b8a87/ty-0.0.74-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:795f763b3ded85574c2c2846a6fb8acf2aa76e9e83d761143e92b1f0c7ffa2cd", size = 13344891, upload-time = "2026-08-22T15:05:32.033Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/9ff7449a4c7e6428f2c6f298e74cf24b70668f29d45c249507a723ff3782/ty-0.0.74-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:dc086db5367d912c31c0cc872deb7387290e779a4b9b54fcb944673a7cd52c7b", size = 12395272, upload-time = "2026-08-22T15:05:34.702Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/dd/b23a5b6b35d37df89dc8dc5daa09efd9245a668b50c4c81c25de21567dc1/ty-0.0.74-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0314d7b391cf684e47c2fa093d2ce4c597cfc9b01d9a315fe204aed6359b271b", size = 12573079, upload-time = "2026-08-22T15:05:37.683Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c5/ccba16239d6129533c8b3603458d0f4dd2ba69478e47059073968e74261d/ty-0.0.74-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c4a45dd2e991e8bdae82ba78c8cd051b253f60bc71a6536598fa3ef580b4fc9b", size = 12832506, upload-time = "2026-08-22T15:05:40.505Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1c/2390912634dff4f341f97b397f2aee341ff062be0a66cda37d59375454f2/ty-0.0.74-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:210e2eac6b018fb934e2b8dac3956a0ba076a3fb1fa6f135058c825e5b759b81", size = 13154752, upload-time = "2026-08-22T15:05:43.355Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/a8c12188227e6f74f91853a7374e01ed81d6ad21c16c8b70e92dbebfe46a/ty-0.0.74-py3-none-win32.whl", hash = "sha256:db0bb6a8f098ef9bd1be861f73b4f7c0320d40d4c05c7ae0a8677d4e7aa4f6e5", size = 12130002, upload-time = "2026-08-22T15:05:46.058Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5c/064f28ccb9c234cfce5a2f7aa69a256663d5ae5bb0290b3a9706cc4d1e4c/ty-0.0.74-py3-none-win_amd64.whl", hash = "sha256:bebff181515255b3c78bd2e7693ae66fab6064ad4feea2065c68bc01022aa678", size = 12771435, upload-time = "2026-08-22T15:05:48.811Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/06/d6becdaca0315346c26b6df97cb0eafa81de4f870945d6989e88704374ed/ty-0.0.74-py3-none-win_arm64.whl", hash = "sha256:1a3469eaaf8c85b1c0a15bede25d36daea4b09fce1d913e965b24e24b3f1d6c6", size = 12558299, upload-time = "2026-08-22T15:05:51.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Align the Flight log helper with the public tabular result and ensure minimal installations can materialize timezone-aware timestamps while keeping deprecated aliases compatible.

### Codex description

- expose `line_number`, `reported_at`, and `line` from `md_get_flight_logs`
- preserve the deprecated log helpers’ `logs` alias and declare the required runtime timezone dependency
- update release metadata, documentation, regression coverage, and `ty` to 0.0.74