### PR TITLE
refactor: centralize register parameter lookup

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -334,20 +334,21 @@ _BEGIN_TRANSACTION_ISOLATION_RE = re.compile(
 )
 
 
+def _first_present_register_value(
+    parameters: Mapping[str, Any], keys: Sequence[str]
+) -> Optional[Any]:
+    for key in keys:
+        if key in parameters:
+            return parameters[key]
+    return None
+
+
 def _parse_register_params(parameters: Optional[Any]) -> Tuple[str, Any]:
     if parameters is None:
         raise ValueError("register requires a view name and data")
     if isinstance(parameters, dict):
-        view_name = None
-        for key in _REGISTER_NAME_KEYS:
-            if key in parameters:
-                view_name = parameters[key]
-                break
-        df = None
-        for key in _REGISTER_DATA_KEYS:
-            if key in parameters:
-                df = parameters[key]
-                break
+        view_name = _first_present_register_value(parameters, _REGISTER_NAME_KEYS)
+        df = _first_present_register_value(parameters, _REGISTER_DATA_KEYS)
         if view_name is None or df is None:
             raise ValueError("register requires a view name and data (tuple or dict)")
         return view_name, df

--- a/duckdb_sqlalchemy/tests/test_core_units.py
+++ b/duckdb_sqlalchemy/tests/test_core_units.py
@@ -1908,11 +1908,28 @@ def test_copy_from_rows_closes_rotated_tempfiles(
     assert all(not Path(temp.name).exists() for temp in created)
 
 
-def test_parse_register_params_dict_and_tuple() -> None:
-    view_name, df = _parse_register_params({"view_name": "v", "df": "data"})
+@pytest.mark.parametrize("name_key", ["name", "view_name", "table"])
+@pytest.mark.parametrize("data_key", ["df", "dataframe", "relation", "data"])
+def test_parse_register_params_dict_aliases(name_key: str, data_key: str) -> None:
+    view_name, df = _parse_register_params({name_key: "v", data_key: "data"})
     assert view_name == "v"
     assert df == "data"
 
+
+def test_parse_register_params_prefers_canonical_keys() -> None:
+    view_name, df = _parse_register_params(
+        {
+            "name": "preferred-name",
+            "view_name": "fallback-name",
+            "df": "preferred-data",
+            "dataframe": "fallback-data",
+        }
+    )
+    assert view_name == "preferred-name"
+    assert df == "preferred-data"
+
+
+def test_parse_register_params_tuple() -> None:
     view_name, df = _parse_register_params(("v2", "data2"))
     assert view_name == "v2"
     assert df == "data2"


### PR DESCRIPTION
The register compatibility path repeats ordered alias lookup for view names and data payloads. This PR centralizes that lookup while preserving accepted aliases and their precedence.

### Codex description

- reuse one private helper for ordered register parameter aliases
- cover every supported dictionary alias plus canonical-key precedence
