### PR TITLE
refactor: extract pool selection policy

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -52,6 +52,12 @@ from ._bulk_insert import build_bulk_insert_data as _build_bulk_insert_data
 from ._bulk_insert import (
     infer_bulk_insert_column_keys as _infer_bulk_insert_column_keys,
 )
+from ._pool import (
+    _default_pool_class_for_database,
+    _looks_like_motherduck,
+    _pool_class_from_override,
+    _pool_override_from_url,
+)
 from ._statements import (
     DISCONNECT_ERROR_PATTERNS,
     _is_idempotent_statement,
@@ -65,7 +71,6 @@ from .config import apply_config, get_core_config
 from .datatypes import ISCHEMA_NAMES, register_extension_types
 from .motherduck import (
     DIALECT_QUERY_KEYS,
-    MOTHERDUCK_CONFIG_KEYS,
     MotherDuckURL,
     _database_with_path_query,
     _normalize_config_aliases,
@@ -571,58 +576,6 @@ class DuckDBExecutionContext(_PGExecutionContext):
         ):
             return DuckDBArrowResult(result)
         return result
-
-
-def _looks_like_motherduck(database: Optional[str], config: Dict[str, Any]) -> bool:
-    if database is not None and (
-        database.startswith("md:") or database.startswith("motherduck:")
-    ):
-        return True
-    return any(k in config for k in MOTHERDUCK_CONFIG_KEYS)
-
-
-def _pool_override_from_url(url: SAURL) -> Optional[str]:
-    value = None
-    if "duckdb_sqlalchemy_pool" in url.query:
-        value = url.query.get("duckdb_sqlalchemy_pool")
-    elif "pool" in url.query:
-        value = url.query.get("pool")
-    if value is None:
-        value = os.getenv("DUCKDB_SQLALCHEMY_POOL")
-    if isinstance(value, (list, tuple)):
-        value = value[0] if value else None
-    if value is None:
-        return None
-    return str(value).lower()
-
-
-_POOL_CLASS_OVERRIDES: Dict[str, type[pool.Pool]] = {
-    "queue": pool.QueuePool,
-    "singleton": pool.SingletonThreadPool,
-    "singletonthreadpool": pool.SingletonThreadPool,
-    "null": pool.NullPool,
-    "nullpool": pool.NullPool,
-}
-
-
-def _pool_class_from_override(
-    pool_override: Optional[str],
-) -> Optional[type[pool.Pool]]:
-    if pool_override is None:
-        return None
-    return _POOL_CLASS_OVERRIDES.get(pool_override)
-
-
-def _default_pool_class_for_database(
-    database: Optional[str], query: Dict[str, Any]
-) -> type[pool.Pool]:
-    if database == ":memory:":
-        return pool.SingletonThreadPool
-    if not database or database.startswith(":memory:"):
-        return pool.QueuePool
-    if _looks_like_motherduck(database, query):
-        return pool.NullPool
-    return pool.QueuePool
 
 
 def _apply_motherduck_defaults(config: Dict[str, Any], database: Optional[str]) -> None:

--- a/duckdb_sqlalchemy/_pool.py
+++ b/duckdb_sqlalchemy/_pool.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping, Optional
+
+from sqlalchemy import pool
+from sqlalchemy.engine.url import URL as SAURL
+
+from .motherduck import MOTHERDUCK_CONFIG_KEYS
+
+_POOL_CLASS_OVERRIDES: Mapping[str, type[pool.Pool]] = {
+    "queue": pool.QueuePool,
+    "singleton": pool.SingletonThreadPool,
+    "singletonthreadpool": pool.SingletonThreadPool,
+    "null": pool.NullPool,
+    "nullpool": pool.NullPool,
+}
+
+
+def _looks_like_motherduck(database: Optional[str], config: Mapping[str, Any]) -> bool:
+    if database is not None and database.startswith(("md:", "motherduck:")):
+        return True
+    return any(key in config for key in MOTHERDUCK_CONFIG_KEYS)
+
+
+def _pool_override_from_url(url: SAURL) -> Optional[str]:
+    value = None
+    if "duckdb_sqlalchemy_pool" in url.query:
+        value = url.query.get("duckdb_sqlalchemy_pool")
+    elif "pool" in url.query:
+        value = url.query.get("pool")
+    if value is None:
+        value = os.getenv("DUCKDB_SQLALCHEMY_POOL")
+    if isinstance(value, (list, tuple)):
+        value = value[0] if value else None
+    if value is None:
+        return None
+    return str(value).lower()
+
+
+def _pool_class_from_override(
+    pool_override: Optional[str],
+) -> Optional[type[pool.Pool]]:
+    if pool_override is None:
+        return None
+    return _POOL_CLASS_OVERRIDES.get(pool_override)
+
+
+def _default_pool_class_for_database(
+    database: Optional[str], query: Mapping[str, Any]
+) -> type[pool.Pool]:
+    if database == ":memory:":
+        return pool.SingletonThreadPool
+    if not database or database.startswith(":memory:"):
+        return pool.QueuePool
+    if _looks_like_motherduck(database, query):
+        return pool.NullPool
+    return pool.QueuePool


### PR DESCRIPTION
Moves the stable pool-selection policy out of the package initializer into a focused private module, keeping the dialect behavior unchanged while making the main module easier to navigate.

### Codex description

- centralize pool overrides, MotherDuck detection, and default pool choices in `_pool.py`
- preserve existing private imports and pool-selection behavior