### PR TITLE
refactor: extract checkpoint helper

### DIFF
--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -41,7 +41,7 @@ from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.engine.default import DefaultDialect, DefaultExecutionContext
 from sqlalchemy.engine.reflection import ReflectionDefaults, cache
 from sqlalchemy.engine.url import URL as SAURL
-from sqlalchemy.exc import InvalidRequestError, NoSuchTableError
+from sqlalchemy.exc import NoSuchTableError
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import bindparam
 from sqlalchemy.sql.compiler import IdentifierPreparer
@@ -52,6 +52,7 @@ from ._bulk_insert import build_bulk_insert_data as _build_bulk_insert_data
 from ._bulk_insert import (
     infer_bulk_insert_column_keys as _infer_bulk_insert_column_keys,
 )
+from ._checkpoint import checkpoint
 from ._pool import (
     _default_pool_class_for_database,
     _looks_like_motherduck,
@@ -233,42 +234,6 @@ __all__ = [
     "copy_from_rows",
     "checkpoint",
 ]
-
-
-def checkpoint(connection: Any, *, force: bool = False, commit: bool = True) -> None:
-    """Run CHECKPOINT with explicit transaction handling.
-
-    SQLAlchemy 2.x connections autobegin transactions on first use. Running
-    ``CHECKPOINT`` inside that transaction can leave the connection in an
-    aborted state after local writes. This helper mirrors the raw DuckDB
-    workflow by committing before and after the checkpoint when requested.
-    """
-
-    statement = "FORCE CHECKPOINT" if force else "CHECKPOINT"
-
-    if hasattr(connection, "exec_driver_sql"):
-        if connection.in_nested_transaction():
-            raise InvalidRequestError(
-                "checkpoint() does not support nested transactions"
-            )
-        if commit and connection.in_transaction():
-            connection.commit()
-        connection.exec_driver_sql(statement)
-        if commit and connection.in_transaction():
-            connection.commit()
-        return
-
-    if hasattr(connection, "execute") and hasattr(connection, "commit"):
-        if commit:
-            connection.commit()
-        connection.execute(statement)
-        if commit:
-            connection.commit()
-        return
-
-    raise TypeError(
-        "checkpoint() requires a SQLAlchemy Connection or DuckDB connection"
-    )
 
 
 class DBAPI:

--- a/duckdb_sqlalchemy/_checkpoint.py
+++ b/duckdb_sqlalchemy/_checkpoint.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+from sqlalchemy.exc import InvalidRequestError
+
+
+def checkpoint(connection: Any, *, force: bool = False, commit: bool = True) -> None:
+    """Run CHECKPOINT with explicit transaction handling.
+
+    SQLAlchemy 2.x connections autobegin transactions on first use. Running
+    ``CHECKPOINT`` inside that transaction can leave the connection in an
+    aborted state after local writes. This helper mirrors the raw DuckDB
+    workflow by committing before and after the checkpoint when requested.
+    """
+
+    statement = "FORCE CHECKPOINT" if force else "CHECKPOINT"
+
+    if hasattr(connection, "exec_driver_sql"):
+        if connection.in_nested_transaction():
+            raise InvalidRequestError(
+                "checkpoint() does not support nested transactions"
+            )
+        if commit and connection.in_transaction():
+            connection.commit()
+        connection.exec_driver_sql(statement)
+        if commit and connection.in_transaction():
+            connection.commit()
+        return
+
+    if hasattr(connection, "execute") and hasattr(connection, "commit"):
+        if commit:
+            connection.commit()
+        connection.execute(statement)
+        if commit:
+            connection.commit()
+        return
+
+    raise TypeError(
+        "checkpoint() requires a SQLAlchemy Connection or DuckDB connection"
+    )


### PR DESCRIPTION
Moves the standalone checkpoint helper out of the package initializer into a focused private module, preserving its public import and transaction behavior while making the main dialect module easier to navigate.

### Codex description

- extract checkpoint transaction handling into `_checkpoint.py`
- preserve the top-level `checkpoint` API and existing behavior