### PR TITLE
fix bulk insert column order corruption

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         language: python
         files: ^duckdb_sqlalchemy/(?!tests/).*\.py$
         additional_dependencies:
-          - "ty==0.0.78"
+          - "ty==0.0.80"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: 'v0.16.6'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ preserved from the upstream project for historical context.
 
 ### Bug Fixes
 
-- preserve compiled positional column order in bulk inserts so the register fast path cannot write values into the wrong columns
+- preserve compiled positional column order in bulk inserts so the register fast path cannot write values into the wrong columns ([#161](https://github.com/leonardovida/duckdb-sqlalchemy/pull/161))
 
 ### Features
 
@@ -23,7 +23,7 @@ preserved from the upstream project for historical context.
 
 ### Tooling
 
-- test SQLAlchemy 2.1.0rc2, update `ty` to 0.0.80 and Ruff to 0.16.6, and refresh compatible locked development dependencies
+- test SQLAlchemy 2.1.0rc2, update `ty` to 0.0.80 and Ruff to 0.16.6, and refresh compatible locked development dependencies ([#157](https://github.com/leonardovida/duckdb-sqlalchemy/pull/157), [#161](https://github.com/leonardovida/duckdb-sqlalchemy/pull/161))
 
 ## [1.5.5.4](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.5.3...v1.5.5.4) (2026-08-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,24 @@ preserved from the upstream project for historical context.
 
 ## Maintained in this fork
 
-## Unreleased
+## [1.5.5.5](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.5.4...v1.5.5.5) (2026-09-10)
+
+### Bug Fixes
+
+- preserve compiled positional column order in bulk inserts so the register fast path cannot write values into the wrong columns
 
 ### Features
 
-- add `md_get_flight_run` for retrieving one MotherDuck Flight run with typed SQLAlchemy columns
+- add `md_get_flight_run` for retrieving one MotherDuck Flight run with typed SQLAlchemy columns ([#157](https://github.com/leonardovida/duckdb-sqlalchemy/pull/157))
+
+### Maintenance
+
+- centralize ordered register parameter alias lookup while preserving accepted aliases and precedence ([#158](https://github.com/leonardovida/duckdb-sqlalchemy/pull/158))
+- extract pool-selection policy and checkpoint transaction handling into focused private modules without changing public behavior ([#159](https://github.com/leonardovida/duckdb-sqlalchemy/pull/159), [#160](https://github.com/leonardovida/duckdb-sqlalchemy/pull/160))
 
 ### Tooling
 
-- test SQLAlchemy 2.1.0rc1, update `ty` to 0.0.78 and Ruff to 0.16.6, and refresh compatible locked development dependencies
+- test SQLAlchemy 2.1.0rc2, update `ty` to 0.0.80 and Ruff to 0.16.6, and refresh compatible locked development dependencies
 
 ## [1.5.5.4](https://github.com/leonardovida/duckdb-sqlalchemy/compare/v1.5.5.3...v1.5.5.4) (2026-08-28)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Current direction in this repository:
 | Component | Supported versions |
 | --- | --- |
 | Python | 3.9+ |
-| SQLAlchemy | 2.0.0+ on Python <3.14; 2.0.45+ on Python 3.14+; SQLAlchemy 2.1 requires Python 3.11+ (tested: 2.0.0, 2.0.52, 2.1.0rc1) |
+| SQLAlchemy | 2.0.0+ on Python <3.14; 2.0.45+ on Python 3.14+; SQLAlchemy 2.1 requires Python 3.11+ (tested: 2.0.0, 2.0.52, 2.1.0rc2) |
 | DuckDB | 0.5.0+ (tested currently: 1.3.0 to 1.5.5) |
 
 ## Install

--- a/duckdb_sqlalchemy/__init__.py
+++ b/duckdb_sqlalchemy/__init__.py
@@ -144,7 +144,7 @@ else:
 try:
     __version__ = package_version("duckdb-sqlalchemy")
 except PackageNotFoundError:  # pragma: no cover - source tree import fallback
-    __version__ = "1.5.5.4"
+    __version__ = "1.5.5.5"
 sqlalchemy_version = sqlalchemy.__version__
 SQLALCHEMY_VERSION = Version(sqlalchemy_version)
 SQLALCHEMY_2 = SQLALCHEMY_VERSION >= Version("2.0.0")
@@ -1707,9 +1707,9 @@ class Dialect(PGDialect_psycopg2):
         if getattr(stmt, "_post_values_clause", None) is not None:
             return False
 
-        column_keys = getattr(compiled, "column_keys", None)
+        column_keys = getattr(compiled, "positiontup", None)
         if not column_keys:
-            column_keys = getattr(compiled, "positiontup", None)
+            column_keys = getattr(compiled, "column_keys", None)
         if not column_keys:
             column_keys = _infer_bulk_insert_column_keys(parameters)
         if not column_keys:

--- a/duckdb_sqlalchemy/tests/test_execution_options.py
+++ b/duckdb_sqlalchemy/tests/test_execution_options.py
@@ -36,6 +36,38 @@ def test_bulk_insert_register_path() -> None:
         assert result == [(1, "Ada"), (2, "Grace")]
 
 
+def test_bulk_insert_register_path_preserves_compiled_position_order() -> None:
+    if (
+        importlib.util.find_spec("pandas") is None
+        and importlib.util.find_spec("pyarrow") is None
+    ):
+        pytest.skip("pandas or pyarrow is required for bulk insert fast path")
+
+    engine = create_engine("duckdb:///:memory:", use_insertmanyvalues=False)
+    md = MetaData()
+    t = Table(
+        "ordered_bulk_insert",
+        md,
+        Column("z_col", String),
+        Column("a_col", String),
+        Column("m_col", String),
+    )
+    md.create_all(engine)
+
+    rows = [
+        {"z_col": "Z", "a_col": "A", "m_col": "M"},
+        {"z_col": "Z2", "a_col": "A2", "m_col": "M2"},
+    ]
+
+    with engine.begin() as conn:
+        conn.execution_options(duckdb_copy_threshold=1).execute(t.insert(), rows)
+
+    with engine.connect() as conn:
+        result = conn.execute(select(t.c.z_col, t.c.a_col, t.c.m_col)).fetchall()
+
+    assert result == [("Z", "A", "M"), ("Z2", "A2", "M2")]
+
+
 def test_build_bulk_insert_data_handles_positional_rows() -> None:
     if (
         importlib.util.find_spec("pandas") is None

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,18 +43,18 @@ def group(title: str) -> Generator[None, None, None]:
         "1.5.5",
     ],
 )
-@nox.parametrize("sqlalchemy", ["2.0.0", "2.0.52", "2.1.0rc1"])
+@nox.parametrize("sqlalchemy", ["2.0.0", "2.0.52", "2.1.0rc2"])
 def tests(session: nox.Session, duckdb: str, sqlalchemy: str) -> None:
     if session.python == "3.14" and sqlalchemy == "2.0.0":
         session.skip("SQLAlchemy 2.0.0 is not compatible with Python 3.14")
-    if session.python == "3.10" and sqlalchemy == "2.1.0rc1":
-        session.skip("SQLAlchemy 2.1.0rc1 requires Python 3.11 or newer")
+    if session.python == "3.10" and sqlalchemy == "2.1.0rc2":
+        session.skip("SQLAlchemy 2.1.0rc2 requires Python 3.11 or newer")
     tests_core(session, duckdb, sqlalchemy)
 
 
 @nox.session(py=["3.11"])
 def nightly(session: nox.Session) -> None:
-    tests_core(session, "master", "2.1.0rc1", remote_data=False)
+    tests_core(session, "master", "2.1.0rc2", remote_data=False)
 
 
 def tests_core(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-sqlalchemy"
-version = "1.5.5.4"
+version = "1.5.5.5"
 description = "DuckDB SQLAlchemy dialect for DuckDB and MotherDuck"
 authors = [
     {name = "Leonardo Vida", email = "lleonardovida@gmail.com"},
@@ -48,7 +48,7 @@ dev = [
     "nox>=2026.4.10,<2027.0.0",
     "pyarrow>=22.0.0; python_version >= '3.10'",
     "pytest>=8.0.0,<10.0.0",
-    "ty==0.0.78",
+    "ty==0.0.80",
     "hypothesis>=6.75.2,<7.0.0",
     "github-action-utils>=1.1.0,<2.0.0",
     "pandas>=1,<2.0; python_version < '3.12'",

--- a/uv.lock
+++ b/uv.lock
@@ -702,7 +702,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-sqlalchemy"
-version = "1.5.5.4"
+version = "1.5.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb", version = "1.4.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -768,7 +768,7 @@ requires-dist = [
     { name = "sqlalchemy", marker = "python_full_version < '3.14'", specifier = ">=2.0.0" },
     { name = "sqlalchemy", marker = "python_full_version >= '3.14'", specifier = ">=2.0.45" },
     { name = "toml", marker = "extra == 'dev'", specifier = ">=0.10.2,<0.11.0" },
-    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.78" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.80" },
 ]
 provides-extras = ["dev", "devtools"]
 
@@ -777,7 +777,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2423,27 +2423,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.78"
+version = "0.0.80"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/c7/2ba0861384c5b5097ac354383abb98188112cb330208c21d5197e98a29e5/ty-0.0.78.tar.gz", hash = "sha256:770b45854f85fa11595208f08c0f28df80943164d10a2832d86be6ac29f135b2", size = 7050609, upload-time = "2026-09-02T22:41:33.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/b0/6d1b10e0d422736a3c439e487c950ae785f401d71ff879d5be68bccb6d90/ty-0.0.80.tar.gz", hash = "sha256:fe86bc91327e45ff5e3593b7e306e7f57a44bc0608f38d647b8d97bd99c96013", size = 7183998, upload-time = "2026-09-09T21:18:47.547Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/ed/f34cfc06a9ba72979df219e48dae1a0b6a6c74a340763ccd30a547edf913/ty-0.0.78-py3-none-linux_armv6l.whl", hash = "sha256:122700b98f9d45785c1ce91a9418154562e7f64f4bf34679f6f7b38c5b97453f", size = 13304624, upload-time = "2026-09-02T22:40:56.649Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/28/5576e2a08b57676d9b2a736d528f077a6c6e32c3d1de2d75dbbe28346966/ty-0.0.78-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cbe7e3709ccf29ef3d9f58f5914cc30ec36fb647008a5a4ff8483abe401bfe8d", size = 12928383, upload-time = "2026-09-02T22:40:59.162Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e0/027d49c3da5235e634da3d3fc52c4874ec89f50830388c9c259f8fb71e0e/ty-0.0.78-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c3528897b3ab9d3589561bc2b5e61a4d5d686de527a4400bb09a439b922a6c70", size = 12730058, upload-time = "2026-09-02T22:41:01.235Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/bc/6bf8ffefd8063730a70ae889cf85def72bc155fd1453135ebf8a09c2f1c2/ty-0.0.78-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8bfba4c44a06484093f527b8ef43a317abcf91395b49396170266629eedf74aa", size = 12813321, upload-time = "2026-09-02T22:41:03.251Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/c0/b3cdf26f82108908d92fdb7ddb741019c446ceb666cf204d4dbf611bde33/ty-0.0.78-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f903c06fdee17baf8373173039ab28f1bce28e66b1c734929a5f50b37eb54d9", size = 13072219, upload-time = "2026-09-02T22:41:05.225Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/36/16bfb0abdd178dae11dbc4b57b9a86c2b62642a18c1103fd2c2930aa5879/ty-0.0.78-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd83e5fe3f07291d1bd4e591f8d2607c204f3eab53bcb1b8060c40e876e1aa61", size = 13903958, upload-time = "2026-09-02T22:41:07.333Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/0c/74d3b1f0344b13156c719dd68a7edf7e48c2051718c9f326ba3cbf45ea53/ty-0.0.78-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:325285377319cf7168a2b8b771ae5027f411530e3c7eab1faf4583cdd72fd7c9", size = 14355581, upload-time = "2026-09-02T22:41:09.56Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/d7/7ca0359e1e61b15b8b02328c8d120db3c507876b9b7c6bd9f26935353e0e/ty-0.0.78-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b7846a404da6492697b524a769755ee9bee157d67674063ecd9c5f69dc52ff", size = 14044749, upload-time = "2026-09-02T22:41:11.678Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/6a/731f16ff42c5fc96e742c2f4e0a6915356bae114ae02ae4af6f33502175f/ty-0.0.78-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:169d3b9d134c0b48fe1af8a844142d374655552054a9d6c15a4b6e51bb0382ea", size = 13391647, upload-time = "2026-09-02T22:41:13.928Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/af/250cc29daf310e837188509ea4d78460c495d8a74c4fb84b4152d9ef2d4f/ty-0.0.78-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:6108cb3b2d28dac5981d4e25008a0a5547d8c877a67f6da9e8c38e7e946be44f", size = 13945020, upload-time = "2026-09-02T22:41:15.968Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/f9/96aab1dee4535e66554e8dc7657c69f6c61c181d8e70b9c3527908e93ef4/ty-0.0.78-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:589ad03608d9d2975ef4b23c41c4f847e325bcc7686f51d4c66066b8dbc18a2a", size = 12851149, upload-time = "2026-09-02T22:41:18.06Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b0/53d8fe9a847534ef5fe2165c7d5292cb853b29dfd7011cbfb1cdb90a8012/ty-0.0.78-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b3fa0786edc1af06030f872d83499c0cea7c261dbbb651e0aee8306bf2c8a869", size = 13091464, upload-time = "2026-09-02T22:41:20.227Z" },
-    { url = "https://files.pythonhosted.org/packages/21/65/94a4e5a02de559f6c6c0ee7a14b88660b4eee058ec6fec5c0ff6ecfbf5cc/ty-0.0.78-py3-none-musllinux_1_2_i686.whl", hash = "sha256:92c5639befc577578c8abd4e5a7fccf98d828db98b09e8d4dd81605dc0e54aef", size = 13389389, upload-time = "2026-09-02T22:41:22.27Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b6/d0c7fe6be64ca5a15100c4b1f0e39c19660d53bc544f609fa117b346e661/ty-0.0.78-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0dce70bc51652b2775debd1d1e422fb0179f5207c73deb4d5d0aca37e5f61695", size = 13691928, upload-time = "2026-09-02T22:41:24.292Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/5d/36081205611ba3fa802efc4ad63e4b1e949bda2f7bb37b34ac9bb6c00db0/ty-0.0.78-py3-none-win32.whl", hash = "sha256:1c80976ca9185d7a9d1baab1fb57240331b8dac58d3b11e46200284086a6de8d", size = 12647346, upload-time = "2026-09-02T22:41:26.699Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/89/b925fe1ea1bc56fc7f11d2496e29072fdd2ceb7b389884fc7b2d07cf0c41/ty-0.0.78-py3-none-win_amd64.whl", hash = "sha256:32e82b704471eab34f67b51c151660ca8a00815977b28278905d76fba54f7415", size = 13241810, upload-time = "2026-09-02T22:41:28.857Z" },
-    { url = "https://files.pythonhosted.org/packages/91/f1/090ef7b52355bcedfbfbff6ce70fa81ba5bd5f6ed3f8d99ae05e6f2fe75b/ty-0.0.78-py3-none-win_arm64.whl", hash = "sha256:3a14d641a3c04fa9a80f2a46be1531d915f60d4fb79d4b894627bbe46bb35d64", size = 13077433, upload-time = "2026-09-02T22:41:31.525Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c8/3c93195eca282936ebb574d0ba98843e4b147ee324006f88464777012a92/ty-0.0.80-py3-none-linux_armv6l.whl", hash = "sha256:738d1cfca466c577aea24547c348629c00c63548cf7da2c46b497b3840f85dee", size = 13606509, upload-time = "2026-09-09T21:18:10.476Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/48/bbb47f7001c97262a5109bcd92a45bcc8a2fbb21e994c214a9897630bfb7/ty-0.0.80-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:56060164bb8ee43770fa367524fbdba2611fc90f8923a02cc91f80eb37d5a1b0", size = 13203812, upload-time = "2026-09-09T21:18:12.796Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/fd141160567047b742e466be8ed09a4c4ed80fa045d37f946eb4f4532fee/ty-0.0.80-py3-none-macosx_11_0_arm64.whl", hash = "sha256:da4062e0fbf3923d9b71688157c5753394f243348f00732e9edbb27498397169", size = 13021896, upload-time = "2026-09-09T21:18:15.186Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/10/b4177faf9e71bc37bc4d08f512042269660a1ce0ec457c48f96e51fc91d7/ty-0.0.80-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9eb94b2659f506a3a07a9ea1415d5c18aaa1e554adc1612614d617a0ed320e1", size = 13083881, upload-time = "2026-09-09T21:18:17.616Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c2/192d48b9a9acbbe030fc9a4bd73af75671a5566e731949f77e912a68ce68/ty-0.0.80-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2f5e39a87da48c1af1a3b3135f02be7a83a93da30b0d6a5f5d27806e7c747ce", size = 13354874, upload-time = "2026-09-09T21:18:19.744Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5b/736dfd31efd98bed9dbe018ff91676e5ea83485b1e24afb635fd0247728f/ty-0.0.80-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e00149e7779c6b98f3ba12e10a631a861bd7ca1a42bbf064e2677ada7d2c0c2", size = 14204805, upload-time = "2026-09-09T21:18:21.999Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/557c726cb53401998e3589bb632c963a6887a70240e0a4386024f3731c81/ty-0.0.80-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a377268f359fb6e7a2cc9026a09223c764f58d020dec8e6baeaba9caba6ff829", size = 14630014, upload-time = "2026-09-09T21:18:24Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/19/7a4b18fe27f6b6bd4ffa56b67c8b09ecb76bb4312d1c64b73f65417b4dbd/ty-0.0.80-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4511dbf1b266b9ce5b73e9b28d94468096c2b6da00e2fe205168c32d3b352ca7", size = 14326946, upload-time = "2026-09-09T21:18:26.679Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/95/16dd90805fc7e53ec54ae9fdb1a8b74753fb159a55a170f60f49b9417824/ty-0.0.80-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe95feffa7156800c6f804195acb9fb5846a39671c7192c30fff23351aaf7c31", size = 13705988, upload-time = "2026-09-09T21:18:28.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/09/4e87992c23ab8a742c7d4914ac5fe66fb9301c8464a69fd2ecbc0be3fbcd/ty-0.0.80-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ba26b39f06bc8c3c2c5acd3a147239482b36620cdbca1b9d02e915294854f2cc", size = 14233729, upload-time = "2026-09-09T21:18:30.961Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e9/b8c11fda8e66a1d1cc1a7160ed719a33f4dc0107b1cef6a14e2673965763/ty-0.0.80-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2e6167320888c115a6fbe69893b63fd1c848f9121a454e75e5f612674528e3f3", size = 13173523, upload-time = "2026-09-09T21:18:33.266Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a7/512083fa540c5be1ac8642658f03bfb5bfa6fd168ea4f55e3c0aabe04166/ty-0.0.80-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7aecb62b4de70b479eab07d1779ea66da26dd8b068f50a9330867157312f103c", size = 13373014, upload-time = "2026-09-09T21:18:35.339Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/63/cd2f0ca81fd9b8cafef93bbcf022bf636bc4de8ee7465c6aafeec1d4d52b/ty-0.0.80-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4fed06adacd16b7e2d722f37449021b1419598d0440769701c0f4827faddde63", size = 13667827, upload-time = "2026-09-09T21:18:37.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5d/ebdfdcb2dc099ae74dc4b75511eef0dd398b2fa27006c543543974b4567f/ty-0.0.80-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:09329af6303ce611ec2cfffc995dc1ddf76c9f47194fc1a4d64a984759c25f5b", size = 13963866, upload-time = "2026-09-09T21:18:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/c286d5e1b560cfd16d6e91fdab683718aacf09fc88938ca06dcc9d1c8502/ty-0.0.80-py3-none-win32.whl", hash = "sha256:a81b3b512f7b4c68e42fbd1835633de658809666e9aafd5defa52bbc5197698d", size = 12881806, upload-time = "2026-09-09T21:18:41.507Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c8/3b3a8ac16d47a23ff34bf57c0d99a491860748aea96e0e886b4bfed54f9b/ty-0.0.80-py3-none-win_amd64.whl", hash = "sha256:8043f99878a2ae434781cb881c8a3840dff70c4a5b60bdc5ae84251f35ee063f", size = 13528883, upload-time = "2026-09-09T21:18:43.687Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/71/a6c697930fca76596d7d17f8853120f41a298fd9ea632c901cfca8ca869b/ty-0.0.80-py3-none-win_arm64.whl", hash = "sha256:e277ef034331da5319efc839c064968d24f35715b71c70369cf97d36fe4dcbdb", size = 13370135, upload-time = "2026-09-09T21:18:45.758Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The register-backed executemany fast path used SQLAlchemy's `compiled.column_keys` to label positional DBAPI tuples. SQLAlchemy may expose those keys in a different order from `compiled.positiontup`, so non-alphabetical insert columns could be rotated into the wrong destination columns without an error.

This change uses the compiled positional order first, retains the existing fallbacks, and adds an executable regression with deliberately non-alphabetical columns. It also prepares maintenance release 1.5.5.5, advances prerelease coverage to SQLAlchemy 2.1.0rc2, and updates `ty` to 0.0.80 for current type-checker correctness fixes. No supported Python, DuckDB, or SQLAlchemy range changes.

Validation:
- published 1.5.5.4 wheel reproduction with pandas: expected `Z/A/M`, observed `M/Z/A`
- regression passes with SQLAlchemy 2.0.0 + DuckDB 1.3.0, SQLAlchemy 2.0.52 + DuckDB 1.5.5, and SQLAlchemy 2.1.0rc2 + DuckDB 1.5.5
- full pytest: 287 passed, 8 skipped
- DuckDB prerelease + SQLAlchemy 2.1.0rc2: 254 passed, 40 skipped
- pre-commit
- build and twine check
- isolated 1.5.5.5 wheel smoke with the pandas fast path